### PR TITLE
Fix Introspection in production

### DIFF
--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -19,12 +19,16 @@ const server = new ApolloServer({
   typeDefs,
   resolvers,
   tracing: true,
+  introspection: true,
   playground: {
     // @ts-ignore
     shareEnabled: true,
     tabs: [
       {
-        endpoint: 'https://score.snapshot.org/graphql',
+        endpoint:
+          process.env.NODE_ENV === 'production'
+            ? `https://score.snapshot.org/graphql`
+            : 'http://localhost:3000/graphql/',
         query
       }
     ]


### PR DESCRIPTION
 Introspection and the playground are disabled in production by default
https://www.apollographql.com/docs/apollo-server/testing/graphql-playground/#enabling-graphql-playground-in-production

this will fix this error:
![image](https://user-images.githubusercontent.com/15967809/123049863-a73f0f80-d41d-11eb-9cbb-60287d92584c.png)
