### PR TITLE
Fix strategies undefined issue

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -23,7 +23,7 @@ router.get('/strategies', (req, res) => {
 router.post('/scores', async (req, res) => {
   const { params } = req.body;
   const requestId = req.headers['x-request-id'];
-  const { space = '', network, snapshot = 'latest', strategies, addresses } = params;
+  const { space = '', network, snapshot = 'latest', strategies = [], addresses = [] } = params;
   const strategyNames = strategies.map(strategy => strategy.name);
 
   if (['revotu.eth'].includes(space) || strategyNames.includes('pod-leader'))


### PR DESCRIPTION
Crashing the server 

```js
 const strategyNames = strategies.map(strategy => strategy.name);
                                      ^
 TypeError: Cannot read properties of undefined (reading 'map')
     at /app/build/src/api.js:45:38
     at Layer.handle [as handle_request] (/app/node_modules/express/lib/router/layer.js:95:5)
     at next (/app/node_modules/express/lib/router/route.js:137:13)
     at Route.dispatch (/app/node_modules/express/lib/router/route.js:112:3)
     at Layer.handle [as handle_request] (/app/node_modules/express/lib/router/layer.js:95:5)
     at /app/node_modules/express/lib/router/index.js:281:22
     at Function.process_params (/app/node_modules/express/lib/router/index.js:335:12)
     at next (/app/node_modules/express/lib/router/index.js:275:10)
     at Function.handle (/app/node_modules/express/lib/router/index.js:174:3)
     at router (/app/node_modules/express/lib/router/index.js:47:12)
 Process exited with status 1
State changed from up to crashed
 State changed from crashed to starting

```