### PR TITLE
Strategy parameters should be in same order to maintain consistent key hashes

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import snapshot from '@snapshot-labs/strategies';
 import scores, { blockNumByNetwork } from './scores';
-import { clone, sha256 } from './utils';
+import { clone, sha256, sortObjectByParam } from './utils';
 
 const router = express.Router();
 
@@ -25,7 +25,8 @@ router.post('/scores', async (req, res) => {
   const requestId = req.headers['x-request-id'];
   const { space = '', network, snapshot = 'latest', addresses = [] } = params;
   let { strategies = [] } = params;
-  strategies = Array.isArray(strategies) ? strategies : [];
+  // strategy parameters should be same order to maintain consistent key hashes
+  strategies = Array.isArray(strategies) ? strategies.map(sortObjectByParam) : [];
   const strategyNames = strategies.map(strategy => strategy.name);
 
   if (['revotu.eth'].includes(space) || strategyNames.includes('pod-leader'))
@@ -54,7 +55,15 @@ router.post('/scores', async (req, res) => {
     );
   } catch (e) {
     const strategiesHashes = strategies.map(strategy => sha256(JSON.stringify({ space, network, strategy })));
-    console.log('Get scores failed', network, space, JSON.stringify(strategies), JSON.stringify(e).slice(0, 256), strategiesHashes, requestId);
+    console.log(
+      'Get scores failed',
+      network,
+      space,
+      JSON.stringify(strategies),
+      JSON.stringify(e).slice(0, 256),
+      strategiesHashes,
+      requestId
+    );
     return res.status(500).json({
       jsonrpc: '2.0',
       error: {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,3 +29,14 @@ export function paginateStrategies(space, network, strategies) {
     return strategy;
   });
 }
+
+export function sortObjectByParam(obj) {
+  // sort object by param name
+  const sortedObj = {};
+  Object.keys(obj)
+    .sort()
+    .forEach(function(key) {
+      sortedObj[key] = obj[key];
+    });
+  return sortedObj;
+}


### PR DESCRIPTION
It generates different hash when we pass different order in strategy,

In UI we send this order:
```
"name": "erc20-balance-of",
"network": "25",
"params": ...   
```

In hub when vote close we send this order:```
```
"name": "erc20-balance-of",
"params": ...  ,
"network": "25"
```

Resulting in different hashes and breaking pagination