### PR TITLE
[spark-with-delegation] fix: update delegation space to use provided parameter

### DIFF
--- a/src/strategies/strategies/spark-with-delegation/index.ts
+++ b/src/strategies/strategies/spark-with-delegation/index.ts
@@ -15,7 +15,6 @@ export async function strategy(
 ) {
   addresses = addresses.map(getAddress);
 
-  const delegationSpace = 'sparkfi.eth';
   const sparkStrategies = [
     {
       name: 'erc20-balance-of',
@@ -56,7 +55,7 @@ export async function strategy(
   );
 
   const delegationsData = await getDelegationsData(
-    delegationSpace,
+    space,
     '1',
     addresses,
     snapshot


### PR DESCRIPTION
### Summary
- removed hardcoded delegation space
- used dynamic space parameter instead

### How to test:
#### Before:
```curl
curl --location 'https://score.snapshot.org/api/scores' \
--header 'Content-Type: application/json' \
--data '{
  "params": {
    "space": "youcanjustbuildthings.eth",
    "network": "1",
    "snapshot": "latest",
    "strategies": [
      {
        "__typename": "Strategy",
        "name": "spark-with-delegation",
        "network": "1",
        "params": {
          "symbol": "SPK",
          "whitelistedDelegates": [
            "0x9d7f2498aef38e084033c783c374a6fcb6a5878d"
          ]
        }
      }
    ],
    "addresses": [
      "0x9d7f2498aef38e084033c783c374a6fcb6a5878d"
    ]
  }
}'
```
You will not see any voting power

#### After:
```curl
curl --location 'http://localhost:3003/api/scores' \
--header 'Content-Type: application/json' \
--data '{
  "params": {
    "space": "youcanjustbuildthings.eth",
    "network": "1",
    "snapshot": "latest",
    "strategies": [
      {
        "__typename": "Strategy",
        "name": "spark-with-delegation",
        "network": "1",
        "params": {
          "symbol": "SPK",
          "whitelistedDelegates": [
            "0x9d7f2498aef38e084033c783c374a6fcb6a5878d"
          ]
        }
      }
    ],
    "addresses": [
      "0x9d7f2498aef38e084033c783c374a6fcb6a5878d"
    ]
  }
}'
```

you should see voting power