### PR TITLE
[wagdie-subgraph] fix the subgraph url and handle api key

### DIFF
--- a/src/strategies/strategies/wagdie-subgraph/README.md
+++ b/src/strategies/strategies/wagdie-subgraph/README.md
@@ -18,8 +18,10 @@ The space config will look like this:
 
 ```JSON
 {
-  // subgraphURL for the request
-  "subGraphURL": "https://subgrapher.snapshot.org/subgraph/arbitrum/CiuchCqNbcNs88KkbQqs7PwuaD2DrPqHqxuDVKrJ5ESM",
+  // subgraphURL for the request (The Graph Gateway)
+  "subGraphURL": "https://gateway.thegraph.com/api/subgraphs/id/CiuchCqNbcNs88KkbQqs7PwuaD2DrPqHqxuDVKrJ5ESM",
+  // Optional API key for The Graph Gateway; adds Authorization header
+  "apiKey": "YOUR_API_KEY_HERE",
   // scoreMultiplier can be used to increase users' scores by a certain magnitude
   "scoreMultiplier": 1,
   // Array of location IDs to limit votes to specific locations. Can be set to ["all"] to include all locations. 

--- a/src/strategies/strategies/wagdie-subgraph/examples.json
+++ b/src/strategies/strategies/wagdie-subgraph/examples.json
@@ -4,7 +4,8 @@
     "strategy": {
       "name": "wagdie-subgraph",
       "params": {
-        "subGraphURL": "https://subgrapher.snapshot.org/subgraph/arbitrum/CiuchCqNbcNs88KkbQqs7PwuaD2DrPqHqxuDVKrJ5ESM",
+        "subGraphURL": "https://gateway.thegraph.com/api/subgraphs/id/CiuchCqNbcNs88KkbQqs7PwuaD2DrPqHqxuDVKrJ5ESM",
+        "apiKey": "EXAMPLE_API_KEY",
         "scoreMultiplier": 1,
         "location": ["all"]
       }
@@ -16,6 +17,6 @@
       "0x4F0EceDCd73dA0315134741d9D3830B08fE32e95",
       "0xa027b41dc6fe7abec1b6ac69335383604766623c"
     ],
-    "snapshot": 16470969
+    "snapshot": 23363853
   }
 ]

--- a/src/strategies/strategies/wagdie-subgraph/index.ts
+++ b/src/strategies/strategies/wagdie-subgraph/index.ts
@@ -2,7 +2,8 @@ import { getAddress } from '@ethersproject/address';
 import { subgraphRequest } from '../../utils';
 
 const SUBGRAPH_URL = {
-  '1': 'https://subgrapher.snapshot.org/subgraph/arbitrum/CiuchCqNbcNs88KkbQqs7PwuaD2DrPqHqxuDVKrJ5ESM'
+  // Default to the WAGDIE World Subgraph
+  '1': 'https://gateway.thegraph.com/api/subgraphs/id/CiuchCqNbcNs88KkbQqs7PwuaD2DrPqHqxuDVKrJ5ESM'
 };
 
 export async function strategy(
@@ -19,8 +20,8 @@ export async function strategy(
     scores[getAddress(address)] = 0;
   }
 
-  // If graph doesn't exist return
-  if (!SUBGRAPH_URL[network]) {
+  // If no subgraph URL is provided or known for this network, return
+  if (!options?.subGraphURL && !SUBGRAPH_URL[network]) {
     return scores;
   }
 
@@ -56,7 +57,11 @@ export async function strategy(
 
   let hasNext = true;
   while (hasNext) {
-    const result = await subgraphRequest(SUBGRAPH_URL[network], params);
+    const url = options?.subGraphURL || SUBGRAPH_URL[network];
+    const requestOptions = options?.apiKey
+      ? { headers: { Authorization: `Bearer ${options.apiKey}` } }
+      : undefined;
+    const result = await subgraphRequest(url, params, requestOptions);
 
     const characters = result && result.characters ? result.characters : [];
     const latest = characters[characters.length - 1];

--- a/src/strategies/strategies/wagdie-subgraph/manifest.json
+++ b/src/strategies/strategies/wagdie-subgraph/manifest.json
@@ -1,5 +1,5 @@
 {
   "name": "Wagdie Subgraph",
   "author": "IcculusHerEmissary",
-  "version": "0.2.0"
+  "version": "0.3.0"
 }


### PR DESCRIPTION
The existing strategy was failing to find our subgraph when querying from the `subgrapher.snapshot.org` api endpoint.

Updated to directly use the subgraph url and accept and api key.

If there is a better way to handle this please let me know. 

Tests pass when `apiKey` is provided.