### PR TITLE
[galxe-staking] feat: add token holder balance to voting power

### DIFF
--- a/src/strategies/strategies/galxe-staking/README.md
+++ b/src/strategies/strategies/galxe-staking/README.md
@@ -1,12 +1,13 @@
 # Galxe-Staking
 
-Strategy that returns voting power based on staked GAL token.
+Strategy that returns voting power based on staked GAL token plus token holder balance.
 
 Here is an example of parameters:
 
 ```json
 {
   "address": "0x7bBE09E066077b3888432EedEC958F64B2E47239",
+  "tokenAddress": "0xe4Cc45Bb5DBDA06dB6183E8bf016569f40497Aa5",
   "decimals": 18
 }
 ```

--- a/src/strategies/strategies/galxe-staking/examples.json
+++ b/src/strategies/strategies/galxe-staking/examples.json
@@ -5,6 +5,7 @@
       "name": "galxe-staking",
       "params": {
         "address": "0x7bBE09E066077b3888432EedEC958F64B2E47239",
+        "tokenAddress": "0xe4Cc45Bb5DBDA06dB6183E8bf016569f40497Aa5",
         "decimals": 18
       }
     },

--- a/src/strategies/strategies/galxe-staking/index.ts
+++ b/src/strategies/strategies/galxe-staking/index.ts
@@ -2,8 +2,12 @@ import { BigNumberish } from '@ethersproject/bignumber';
 import { Multicaller } from '../../utils';
 import { formatUnits } from '@ethersproject/units';
 
-const abi = [
+const stakingAbi = [
   'function getStakeAmount(address) external view returns (uint256)'
+];
+
+const tokenAbi = [
+  'function balanceOf(address account) external view returns (uint256)'
 ];
 
 export async function strategy(
@@ -16,17 +20,28 @@ export async function strategy(
 ): Promise<Record<string, number>> {
   const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
 
-  const multi = new Multicaller(network, provider, abi, { blockTag });
-  addresses.forEach(address => {
-    multi.call(address, options.address, 'getStakeAmount', [address]);
+  const stakingMulti = new Multicaller(network, provider, stakingAbi, {
+    blockTag
+  });
+  const tokenMulti = new Multicaller(network, provider, tokenAbi, {
+    blockTag
   });
 
-  const result: Record<string, BigNumberish> = await multi.execute();
+  addresses.forEach(address => {
+    stakingMulti.call(address, options.address, 'getStakeAmount', [address]);
+    tokenMulti.call(address, options.tokenAddress, 'balanceOf', [address]);
+  });
+
+  const [stakingResult, tokenResult]: [
+    Record<string, BigNumberish>,
+    Record<string, BigNumberish>
+  ] = await Promise.all([stakingMulti.execute(), tokenMulti.execute()]);
 
   return Object.fromEntries(
-    Object.entries(result).map(([address, balance]) => [
+    addresses.map(address => [
       address,
-      parseFloat(formatUnits(balance, options.decimals))
+      parseFloat(formatUnits(stakingResult[address], options.decimals)) +
+        parseFloat(formatUnits(tokenResult[address], options.decimals))
     ])
   );
 }

--- a/src/strategies/strategies/galxe-staking/manifest.json
+++ b/src/strategies/strategies/galxe-staking/manifest.json
@@ -1,5 +1,5 @@
 {
   "name": "Galxe Staking",
   "author": "oyyblin",
-  "version": "0.1.0"
+  "version": "0.2.0"
 }

--- a/src/strategies/strategies/galxe-staking/schema.json
+++ b/src/strategies/strategies/galxe-staking/schema.json
@@ -14,7 +14,15 @@
         },
         "address": {
           "type": "string",
-          "title": "Contract address",
+          "title": "Staking contract address",
+          "examples": ["e.g. 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "tokenAddress": {
+          "type": "string",
+          "title": "Token contract address",
           "examples": ["e.g. 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"],
           "pattern": "^0x[a-fA-F0-9]{40}$",
           "minLength": 42,
@@ -26,7 +34,7 @@
           "examples": ["e.g. 18"]
         }
       },
-      "required": ["address", "decimals"],
+      "required": ["address", "tokenAddress", "decimals"],
       "additionalProperties": false
     }
   }


### PR DESCRIPTION
## Summary
- Voting power now = staked amount + wallet token balance (via ERC20 `balanceOf`)
- Added `tokenAddress` required param to specify the ERC20 token contract
- Two parallel Multicaller queries (staking + token) with `Promise.all`

## Changes
- `index.ts`: added `tokenAbi`, second Multicaller for `balanceOf`, results summed
- `schema.json`: added `tokenAddress` field (required)
- `examples.json`: added `tokenAddress` example param
- `README.md`: updated description and example

## Test plan
- [ ] Verify with known addresses that staking + holder balances sum correctly
- [ ] Verify snapshot block tag works for both multicalls
- [ ] Verify error handling when `tokenAddress` is missing