### PR TITLE
[galxe-staking-and-holding] feat: add strategy

### DIFF
--- a/src/strategies/strategies/galxe-staking-and-holding/README.md
+++ b/src/strategies/strategies/galxe-staking-and-holding/README.md
@@ -1,0 +1,13 @@
+# Galxe-Staking-and-Holding
+
+Strategy that returns voting power based on staked GAL token plus token holder balance.
+
+Here is an example of parameters:
+
+```json
+{
+  "stakingAddress": "0x7bBE09E066077b3888432EedEC958F64B2E47239",
+  "tokenAddress": "0xe4Cc45Bb5DBDA06dB6183E8bf016569f40497Aa5",
+  "decimals": 18
+}
+```

--- a/src/strategies/strategies/galxe-staking-and-holding/examples.json
+++ b/src/strategies/strategies/galxe-staking-and-holding/examples.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "Galxe Staking and Holding",
+    "strategy": {
+      "name": "galxe-staking-and-holding",
+      "params": {
+        "stakingAddress": "0x7bBE09E066077b3888432EedEC958F64B2E47239",
+        "tokenAddress": "0xe4Cc45Bb5DBDA06dB6183E8bf016569f40497Aa5",
+        "decimals": 18
+      }
+    },
+    "network": "56",
+    "addresses": [
+      "0x93Cb1a4A9Bdea09162548243fD298F57cFc27F70",
+      "0xb85b3D61439a3d70D3DF7913a3A764F352b32C55",
+      "0x0Eb7570db974F2f57145eA9224A61e280A2E7457"
+    ],
+    "snapshot": 38145814
+  }
+]

--- a/src/strategies/strategies/galxe-staking-and-holding/index.ts
+++ b/src/strategies/strategies/galxe-staking-and-holding/index.ts
@@ -1,0 +1,49 @@
+import { BigNumberish } from '@ethersproject/bignumber';
+import { Multicaller } from '../../utils';
+import { formatUnits } from '@ethersproject/units';
+
+const stakingAbi = [
+  'function getStakeAmount(address) external view returns (uint256)'
+];
+
+const tokenAbi = [
+  'function balanceOf(address account) external view returns (uint256)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const stakingMulti = new Multicaller(network, provider, stakingAbi, {
+    blockTag
+  });
+  const tokenMulti = new Multicaller(network, provider, tokenAbi, {
+    blockTag
+  });
+
+  addresses.forEach(address => {
+    stakingMulti.call(address, options.stakingAddress, 'getStakeAmount', [
+      address
+    ]);
+    tokenMulti.call(address, options.tokenAddress, 'balanceOf', [address]);
+  });
+
+  const [stakingResult, tokenResult]: [
+    Record<string, BigNumberish>,
+    Record<string, BigNumberish>
+  ] = await Promise.all([stakingMulti.execute(), tokenMulti.execute()]);
+
+  return Object.fromEntries(
+    addresses.map(address => [
+      address,
+      parseFloat(formatUnits(stakingResult[address], options.decimals)) +
+        parseFloat(formatUnits(tokenResult[address], options.decimals))
+    ])
+  );
+}

--- a/src/strategies/strategies/galxe-staking-and-holding/manifest.json
+++ b/src/strategies/strategies/galxe-staking-and-holding/manifest.json
@@ -1,5 +1,5 @@
 {
   "name": "Galxe Staking and Holding",
-  "author": "oyyblin",
+  "author": "xmujx",
   "version": "0.1.0"
 }

--- a/src/strategies/strategies/galxe-staking-and-holding/manifest.json
+++ b/src/strategies/strategies/galxe-staking-and-holding/manifest.json
@@ -1,0 +1,5 @@
+{
+  "name": "Galxe Staking and Holding",
+  "author": "oyyblin",
+  "version": "0.1.0"
+}

--- a/src/strategies/strategies/galxe-staking-and-holding/schema.json
+++ b/src/strategies/strategies/galxe-staking-and-holding/schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "type": "string",
+          "title": "Symbol",
+          "examples": ["e.g. GAL"],
+          "maxLength": 16
+        },
+        "stakingAddress": {
+          "type": "string",
+          "title": "Staking contract address",
+          "examples": ["e.g. 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "tokenAddress": {
+          "type": "string",
+          "title": "Token contract address",
+          "examples": ["e.g. 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "decimals": {
+          "type": "number",
+          "title": "Decimals",
+          "examples": ["e.g. 18"]
+        }
+      },
+      "required": ["stakingAddress", "tokenAddress", "decimals"],
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- New strategy: `galxe-staking-and-holding`
- Voting power = staked GAL amount (`getStakeAmount`) + wallet token balance (`balanceOf`)
- Two parallel Multicaller queries via `Promise.all`
- Params: `stakingAddress` (staking contract), `tokenAddress` (ERC20 token), `decimals`

## Test plan
- [ ] Verify staking + holding balances sum correctly for known addresses
- [ ] Verify snapshot block tag works for both multicalls
- [ ] Verify missing param validation via schema