### PR TITLE
[fountainhead] fix: cap multicall batch size to avoid gas-limit reverts

### DIFF
--- a/src/strategies/strategies/fountainhead/index.ts
+++ b/src/strategies/strategies/fountainhead/index.ts
@@ -22,10 +22,7 @@ const DECIMALS = 18;
 // we must bound the number of fontaines per locker to avoid RPC timeouts
 const MAX_FONTAINES_PER_LOCKER = 1024;
 
-// SuperToken balanceOf and the locker getters do real-time balance math, so
-// they are gas-heavy. Cap the number of calls per multicall batch well below
-// the snapshot.js default (500) to stay under RPC nodes' eth_call gas limit.
-const MULTICALL_LIMIT = 100;
+const MULTICALL_LIMIT = 200;
 
 const UNISWAP_V3_SUBGRAPH_URL = {
   '1': 'https://subgrapher.snapshot.org/subgraph/arbitrum/5zvR82QoaXYFyDEKLZ9t6v9adgnptxYpKpSbxtgVENFV',
@@ -52,10 +49,7 @@ export async function strategy(
   const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
 
   // 1. GET LOCKER ADDRESSES
-  const mCall2 = new Multicaller(network, provider, abi, {
-    blockTag,
-    limit: MULTICALL_LIMIT
-  });
+  const mCall2 = new Multicaller(network, provider, abi, { blockTag });
   // lockerFactory.getUserLocker(). Returns the deterministic address and a bool "exists".
   addresses.forEach(address =>
     mCall2.call(address, options.lockerFactoryAddress, 'getUserLocker', [
@@ -111,10 +105,7 @@ export async function strategy(
   });
 
   // 3. GET ALL THE FONTAINES
-  const mCall4 = new Multicaller(network, provider, abi, {
-    blockTag,
-    limit: MULTICALL_LIMIT
-  });
+  const mCall4 = new Multicaller(network, provider, abi, { blockTag });
   existingLockers.forEach(lockerAddress => {
     const fontaineCount = lockerStates[lockerAddress].fontaineCount;
     // iterate backwards, so we have fontaines ordered by creation time (most recent first).

--- a/src/strategies/strategies/fountainhead/index.ts
+++ b/src/strategies/strategies/fountainhead/index.ts
@@ -22,6 +22,11 @@ const DECIMALS = 18;
 // we must bound the number of fontaines per locker to avoid RPC timeouts
 const MAX_FONTAINES_PER_LOCKER = 1024;
 
+// SuperToken balanceOf and the locker getters do real-time balance math, so
+// they are gas-heavy. Cap the number of calls per multicall batch well below
+// the snapshot.js default (500) to stay under RPC nodes' eth_call gas limit.
+const MULTICALL_LIMIT = 100;
+
 const UNISWAP_V3_SUBGRAPH_URL = {
   '1': 'https://subgrapher.snapshot.org/subgraph/arbitrum/5zvR82QoaXYFyDEKLZ9t6v9adgnptxYpKpSbxtgVENFV',
   '8453':
@@ -47,7 +52,10 @@ export async function strategy(
   const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
 
   // 1. GET LOCKER ADDRESSES
-  const mCall2 = new Multicaller(network, provider, abi, { blockTag });
+  const mCall2 = new Multicaller(network, provider, abi, {
+    blockTag,
+    limit: MULTICALL_LIMIT
+  });
   // lockerFactory.getUserLocker(). Returns the deterministic address and a bool "exists".
   addresses.forEach(address =>
     mCall2.call(address, options.lockerFactoryAddress, 'getUserLocker', [
@@ -63,7 +71,10 @@ export async function strategy(
   const existingLockers = Object.values(lockerByAddress);
 
   // 2. GET LOCKER STATE (available balance, staked balance, fontaine count)
-  const mCall3 = new Multicaller(network, provider, abi, { blockTag });
+  const mCall3 = new Multicaller(network, provider, abi, {
+    blockTag,
+    limit: MULTICALL_LIMIT
+  });
   existingLockers.forEach(lockerAddress => {
     mCall3.call(
       `available-${lockerAddress}`,
@@ -100,7 +111,10 @@ export async function strategy(
   });
 
   // 3. GET ALL THE FONTAINES
-  const mCall4 = new Multicaller(network, provider, abi, { blockTag });
+  const mCall4 = new Multicaller(network, provider, abi, {
+    blockTag,
+    limit: MULTICALL_LIMIT
+  });
   existingLockers.forEach(lockerAddress => {
     const fontaineCount = lockerStates[lockerAddress].fontaineCount;
     // iterate backwards, so we have fontaines ordered by creation time (most recent first).
@@ -116,7 +130,10 @@ export async function strategy(
   const fontaineAddrs: Record<string, string> = await mCall4.execute();
 
   // 4. GET UNLOCKED BALANCES AND FONTAINE BALANCES
-  const mCall5 = new Multicaller(network, provider, abi, { blockTag });
+  const mCall5 = new Multicaller(network, provider, abi, {
+    blockTag,
+    limit: MULTICALL_LIMIT
+  });
   addresses.forEach(address =>
     mCall5.call(`unlocked-${address}`, options.tokenAddress, 'balanceOf', [
       address

--- a/src/strategies/utils/delegation.ts
+++ b/src/strategies/utils/delegation.ts
@@ -83,9 +83,12 @@ export async function getDelegationsData(
             getDelegationReverseData(delegation))
       );
 
-    if (space === 'stgdao.eth' && snapshot !== 'latest') {
+    if (
+      ['stgdao.eth', 'superfluid.eth'].includes(space) &&
+      snapshot !== 'latest'
+    ) {
       // TODO: implement LRU so memory doesn't explode
-      // we only cache stgdao for now
+      // we only cache stgdao and superfluid for now
       console.log(`[with-delegation] Caching ${cacheKey}`);
       DELEGATION_DATA_CACHE[cacheKey] = delegationsReverse;
     }

--- a/src/strategies/utils/delegation.ts
+++ b/src/strategies/utils/delegation.ts
@@ -83,12 +83,9 @@ export async function getDelegationsData(
             getDelegationReverseData(delegation))
       );
 
-    if (
-      ['stgdao.eth', 'superfluid.eth'].includes(space) &&
-      snapshot !== 'latest'
-    ) {
+    if (space === 'stgdao.eth' && snapshot !== 'latest') {
       // TODO: implement LRU so memory doesn't explode
-      // we only cache stgdao and superfluid for now
+      // we only cache stgdao for now
       console.log(`[with-delegation] Caching ${cacheKey}`);
       DELEGATION_DATA_CACHE[cacheKey] = delegationsReverse;
     }


### PR DESCRIPTION
## Summary

After #1433, `get_vp` for `superfluid.eth` (and any space whose delegation tree includes the fountainhead strategy with ~1000 delegators) fails with:

```
call revert exception ... reverted with reason string "Multicall3: call failed" (method="aggregate(...)")
```

### Root cause

`snapshot.js`'s `multicall` uses Multicall3's `aggregate`, which runs every sub-call in a single `eth_call` and batches at a default of **500 calls per request**. SUP is a SuperToken, so `balanceOf` (and the locker's `getAvailableBalance`/`getStakedBalance`) perform real-time balance math and are gas-heavy. With ~1000 delegators, a 500-call batch exceeds RPC nodes' `eth_call` gas limit, so a sub-call runs out of gas and the whole `aggregate` reverts with `Multicall3: call failed`.

This is independent of the `MAX_FONTAINES_PER_LOCKER` change — it's driven by the number of delegators, and the largest batch is actually the locker-state call (`getAvailableBalance` + `getStakedBalance` + `fontaineCount` per locker).

### Fix

Pass `limit: 100` to all `Multicaller` instances in the strategy so each `aggregate` batch stays well under the gas ceiling.

## Test plan

- [x] Reproduced the failure end-to-end via `getScoresDirect` with the original payload (delegation → fountainhead for `0x884Ff907...` on `superfluid.eth`, snapshot `46152771`): `Multicall3: call failed` before the change, `{ "0x884Ff907...": 6031821.6... }` after.
- [x] `yarn test:strategy fountainhead` passes.
- [x] Full unit suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)