### PR TITLE
chore: scope tsc compilation to src/ and exclude tests

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,7 @@
     "inlineSources": true,
     "sourceRoot": "/",
     "skipLibCheck": true
-  }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts"]
 }


### PR DESCRIPTION
## Summary
- Adds `"include": ["src/**/*"]` and `"exclude": ["src/**/*.test.ts", "src/**/*.spec.ts"]` to `tsconfig.json`.

## Why
Without these, tsc compiled `test/**/*.test.ts` and colocated `src/**/*.test.ts` files into `build/`, polluting build output.

## Verification
- `rm -rf build && yarn build` — no `*.test.js` / `*.spec.js` files in `build/`
- `yarn typecheck` passes