### PR TITLE
chore: move CI to Node 22

### DIFF
--- a/.github/workflows/create-sentry-release.yml
+++ b/.github/workflows/create-sentry-release.yml
@@ -7,7 +7,11 @@ on:
 
 jobs:
   create-sentry-release:
+    strategy:
+      matrix:
+        target: ['22']
     uses: snapshot-labs/actions/.github/workflows/create-sentry-release.yml@main
     secrets: inherit
     with:
       project: score-api
+      target: ${{ matrix.target }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,5 +6,10 @@ on:
 
 jobs:
   lint:
+    strategy:
+      matrix:
+        target: ['22']
     uses: snapshot-labs/actions/.github/workflows/lint.yml@main
+    with:
+      target: ${{ matrix.target }}
     secrets: inherit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,5 +6,10 @@ on:
 
 jobs:
   test:
+    strategy:
+      matrix:
+        target: ['22']
     uses: snapshot-labs/actions/.github/workflows/test.yml@main
+    with:
+      target: ${{ matrix.target }}
     secrets: inherit

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine AS development
+FROM node:22-alpine AS development
 
 
 RUN apk update && apk upgrade && \

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   },
   "prettier": "@snapshot-labs/prettier-config",
   "engines": {
-    "node": ">=16 < 17 || >= 18"
+    "node": ">=22.6.0"
   },
   "resolutions": {
     "@uniswap/v3-periphery": "1.4.1"


### PR DESCRIPTION
## What

Moves CI and the declared engine to **Node 22** (Active LTS):

- `lint.yml`, `test.yaml`, `create-sentry-release.yml`: add explicit `strategy.matrix.target: ['22']` (was inheriting shared defaults: lint '18', test '16')
- `Dockerfile`: `node:18-alpine` → `node:22-alpine` (avoids CI-on-22 + prod-on-18 drift)
- `package.json` `engines.node`: `>=16 < 17 || >= 18` → `>=22`

## Why

Node 18 is EOL. The pending `@snapshot-labs/eslint-config` bump (#1291) pulls `eslint-visitor-keys@5`, whose engine requires `^20.19.0 || ^22.13.0 || >=24` — so that dependabot PR **cannot pass lint on Node 18**. Moving to Node 22 unblocks it. Node 22 is already what `sx-monorepo` runs, and blockfinder #505 just landed on the same pattern.

This is a **per-repo** change; it does **not** touch the shared `snapshot-labs/actions` defaults, so there's no org-wide blast radius.

## Verified locally on Node 22.19.0

| Check | Result |
|---|---|
| `yarn install` | ✅ |
| `yarn lint` | ✅ |
| `yarn typecheck` | ✅ |
| `yarn build` | ✅ |
| `yarn test:unit` | ✅ — 103/103 (+2 skipped) |
| `yarn test` | ✅ — 169/169 (+3 todo), 15/15 suites |

## Out of scope

`strategy.yml` / `validation.yml` are hand-rolled workflows (not using shared workflows), label-gated, and currently pin no Node version (they get `ubuntu-latest`'s default ≈ Node 20). They're not blocking and can be pinned to Node 22 via `actions/setup-node@v4` in a follow-up if desired.

## Test

CI `lint (22) / Lint` and `test (22) / Test` should both go green on Node 22.