### PR TITLE
chore: group eslint-config + prettier-config dependabot bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,9 @@ updates:
       interval: "daily"
     allow:
       - dependency-name: "@snapshot-labs/*"
+    groups:
+      snapshot-labs-tooling:
+        patterns:
+          - "@snapshot-labs/eslint-config"
+          - "@snapshot-labs/eslint-config-base"
+          - "@snapshot-labs/prettier-config"


### PR DESCRIPTION
## Summary

Adds a `groups` block under the npm ecosystem in `.github/dependabot.yml` so the three `@snapshot-labs` tooling deps (`eslint-config`, `eslint-config-base`, `prettier-config`) consolidate into one PR per bump cycle instead of three.

Other `@snapshot-labs/*` deps (snapshot.js, snapshot-sentry, …) stay as individual PRs — they have real review surface.

## Expected effect on next dependabot poll

- #1291 + #1292 + #1438 → auto-closed, replaced with one grouped PR (`bump the snapshot-labs-tooling group`)
- #1436 (snapshot.js) → unchanged, still its own PR
- #1437 (snapshot-sentry) → unchanged, still its own PR

If this lands cleanly we can replicate the same 6 lines across the other ~10 snapshot-labs repos with a `dependabot.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)