### PR TITLE
chore: widen dependabot group to all @snapshot-labs/* deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,6 @@ updates:
     allow:
       - dependency-name: "@snapshot-labs/*"
     groups:
-      snapshot-labs-tooling:
+      snapshot:
         patterns:
-          - "@snapshot-labs/eslint-config"
-          - "@snapshot-labs/eslint-config-base"
-          - "@snapshot-labs/prettier-config"
+          - "@snapshot-labs/*"


### PR DESCRIPTION
Follow-up to #1443. Widens the group from the eslint/prettier trio to all `@snapshot-labs/*` so it matches the pattern we're rolling out across the org (sx-monorepo, delegate-registry-api, + the 9 new PRs). One grouped PR per cycle for every snapshot-labs bump.

cc @ChaituVR