### PR TITLE
Add voting proxy strategy

### DIFF
--- a/src/strategies/strategies/voting-proxy/README.md
+++ b/src/strategies/strategies/voting-proxy/README.md
@@ -1,0 +1,32 @@
+# voting-proxy
+
+Generic overriding strategy for older multisigs that cannot upgrade to
+ERC-1271, implement native Snapshot contract voting, or move their staked
+position.
+
+The voter submits a Snapshot vote from a small ERC-1271 voting proxy. If that
+proxy has zero direct voting power, this strategy calls `source()` on the proxy,
+scores the returned source address with the configured inner strategies, and
+returns that voting power under the original proxy voter.
+
+If several proxy voters resolve to the same source, a direct source voter wins.
+Otherwise, the lowest proxy address wins deterministically and the other proxies
+return `0`.
+
+Here is an example of parameters:
+
+```json
+{
+  "strategies": [
+    {
+      "name": "erc20-balance-of",
+      "network": "1",
+      "params": {
+        "address": "0xToken",
+        "symbol": "TOKEN",
+        "decimals": 18
+      }
+    }
+  ]
+}
+```

--- a/src/strategies/strategies/voting-proxy/examples.json
+++ b/src/strategies/strategies/voting-proxy/examples.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "Voting proxy with whitelisted source",
+    "strategy": {
+      "name": "voting-proxy",
+      "params": {
+        "strategies": [
+          {
+            "name": "whitelist",
+            "params": {
+              "symbol": "VP",
+              "addresses": ["0x135bb4cc36b5069Bc66130404F68dA593f9Fc2E8"]
+            }
+          }
+        ]
+      }
+    },
+    "network": "56",
+    "addresses": [
+      "0x966885831bD5FdaAe28Fae45dB0B396E3135549c",
+      "0x000000000000000000000000000000000000dEaD",
+      "0x2222222222222222222222222222222222222222"
+    ],
+    "snapshot": 105693000
+  }
+]

--- a/src/strategies/strategies/voting-proxy/index.ts
+++ b/src/strategies/strategies/voting-proxy/index.ts
@@ -1,0 +1,104 @@
+import { getScoresDirect } from '../../utils';
+import type { Snapshot } from '../../types';
+import { scoreWithVotingProxy } from './proxyScoring';
+
+const SOURCE_SELECTOR = '0x67e828bf';
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+type InnerStrategy = {
+  name: string;
+  network?: string;
+  params?: Record<string, unknown>;
+};
+
+export const supportedProtocols = ['evm'];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot: Snapshot
+): Promise<Record<string, number>> {
+  const strategies = options?.strategies;
+  if (!Array.isArray(strategies) || !strategies.length) {
+    throw new Error('voting-proxy requires at least one inner strategy');
+  }
+
+  return scoreWithVotingProxy({
+    addresses,
+    scoreInner: scoringAddresses =>
+      scoreStrategies(
+        space,
+        network,
+        provider,
+        scoringAddresses,
+        strategies,
+        snapshot
+      ),
+    resolveSources: proxies => resolveSources(provider, proxies, snapshot)
+  });
+}
+
+async function scoreStrategies(
+  space: string,
+  network: string,
+  provider,
+  addresses: string[],
+  strategies: InnerStrategy[],
+  snapshot: Snapshot
+): Promise<Record<string, number>> {
+  const totals = Object.fromEntries(addresses.map(address => [address, 0]));
+  const scoresByStrategy = await getScoresDirect(
+    space,
+    strategies,
+    network,
+    provider,
+    addresses,
+    snapshot
+  );
+
+  for (const scores of scoresByStrategy) {
+    for (const [address, score] of Object.entries(scores)) {
+      totals[address] = (totals[address] ?? 0) + Number(score);
+    }
+  }
+
+  return totals;
+}
+
+async function resolveSources(
+  provider,
+  addresses: string[],
+  snapshot: Snapshot
+): Promise<Record<string, string>> {
+  if (!provider?.call) return {};
+
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+  const entries = await Promise.all(
+    addresses.map(async address => {
+      try {
+        const source = decodeSource(
+          await provider.call({ to: address, data: SOURCE_SELECTOR }, blockTag)
+        );
+
+        return source && source !== ZERO_ADDRESS
+          ? [address, source]
+          : undefined;
+      } catch {
+        return undefined;
+      }
+    })
+  );
+
+  return Object.fromEntries(
+    entries.filter((entry): entry is [string, string] => !!entry)
+  );
+}
+
+function decodeSource(result: string): string | undefined {
+  return /^0x[0-9a-fA-F]{64}$/.test(result)
+    ? `0x${result.slice(26).toLowerCase()}`
+    : undefined;
+}

--- a/src/strategies/strategies/voting-proxy/manifest.json
+++ b/src/strategies/strategies/voting-proxy/manifest.json
@@ -1,0 +1,6 @@
+{
+  "name": "Voting Proxy",
+  "author": "orbs-network",
+  "version": "0.1.0",
+  "overriding": true
+}

--- a/src/strategies/strategies/voting-proxy/proxyScoring.ts
+++ b/src/strategies/strategies/voting-proxy/proxyScoring.ts
@@ -1,0 +1,96 @@
+type ScoreMap = Record<string, number>;
+type SourceMap = Record<string, string>;
+
+export async function scoreWithVotingProxy({
+  addresses,
+  scoreInner,
+  resolveSources
+}: {
+  addresses: string[];
+  scoreInner: (addresses: string[]) => Promise<ScoreMap>;
+  resolveSources: (addresses: string[]) => Promise<SourceMap>;
+}): Promise<ScoreMap> {
+  const directScores = normalizeAddressKeys(await scoreInner(addresses));
+  const proxyCandidates = addresses.filter(
+    address => (directScores[addressKey(address)] ?? 0) === 0
+  );
+  const sourcesByProxy = normalizeAddressKeys(
+    proxyCandidates.length ? await resolveSources(proxyCandidates) : {}
+  );
+  const winningProxyBySource = winnersBySource(
+    proxyCandidates,
+    sourcesByProxy,
+    new Set(addresses.map(addressKey))
+  );
+  const sources = Object.keys(winningProxyBySource);
+  const sourceScores = normalizeAddressKeys(
+    sources.length ? await scoreInner(sources) : {}
+  );
+
+  return Object.fromEntries(
+    addresses.map(address => [
+      address,
+      score(
+        address,
+        directScores,
+        sourcesByProxy,
+        winningProxyBySource,
+        sourceScores
+      )
+    ])
+  );
+}
+
+function winnersBySource(
+  proxies: string[],
+  sourcesByProxy: SourceMap,
+  voterKeys: Set<string>
+): SourceMap {
+  const winners: SourceMap = {};
+
+  for (const proxy of proxies) {
+    const source = sourcesByProxy[addressKey(proxy)];
+    const sourceKey = source && addressKey(source);
+    if (!sourceKey || voterKeys.has(sourceKey)) continue;
+
+    const proxyKey = addressKey(proxy);
+    if (!winners[sourceKey] || proxyKey < winners[sourceKey]) {
+      winners[sourceKey] = proxyKey;
+    }
+  }
+
+  return winners;
+}
+
+function score(
+  address: string,
+  directScores: ScoreMap,
+  sourcesByProxy: SourceMap,
+  sourceWinners: SourceMap,
+  sourceScores: ScoreMap
+): number {
+  const key = addressKey(address);
+  const directScore = directScores[key] ?? 0;
+  if (directScore !== 0) return directScore;
+
+  const source = sourcesByProxy[key];
+  if (!source) return 0;
+
+  const sourceKey = addressKey(source);
+  if (sourceWinners[sourceKey] !== key) return 0;
+
+  return sourceScores[sourceKey] ?? 0;
+}
+
+function normalizeAddressKeys<T>(values: Record<string, T>): Record<string, T> {
+  return Object.fromEntries(
+    Object.entries(values).map(([address, value]) => [
+      addressKey(address),
+      value
+    ])
+  );
+}
+
+function addressKey(address: string): string {
+  return address.toLowerCase();
+}

--- a/src/strategies/strategies/voting-proxy/schema.json
+++ b/src/strategies/strategies/voting-proxy/schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "strategies": {
+          "type": "array",
+          "title": "Inner strategies",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "network": {
+                "type": "string"
+              },
+              "params": {
+                "type": "object"
+              }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": ["strategies"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/test/strategies/unit/voting-proxy.test.ts
+++ b/test/strategies/unit/voting-proxy.test.ts
@@ -1,0 +1,88 @@
+import { scoreWithVotingProxy } from '../../../src/strategies/strategies/voting-proxy/proxyScoring';
+
+const direct = address('10');
+const source = address('20');
+const proxyHigh = address('30');
+const proxyLow = address('11');
+
+describe('voting-proxy scoring', () => {
+  it('returns source voting power for a zero-vp proxy voter', async () => {
+    const { result } = await scoreFixture({
+      addresses: [proxyHigh],
+      directScores: { [proxyHigh]: 0 },
+      sourceByProxy: { [proxyHigh]: source },
+      sourceScores: { [source]: 12 }
+    });
+
+    expect(result).toEqual({ [proxyHigh]: 12 });
+  });
+
+  it('keeps direct scores and only resolves zero-vp proxy candidates', async () => {
+    const { result, scoredAddressSets, resolvedAddressSets } =
+      await scoreFixture({
+        addresses: [direct, proxyHigh],
+        directScores: { [direct]: 7, [proxyHigh]: 0 },
+        sourceByProxy: { [proxyHigh]: source },
+        sourceScores: { [source]: 12 }
+      });
+
+    expect(result).toEqual({ [direct]: 7, [proxyHigh]: 12 });
+    expect(scoredAddressSets).toEqual([[direct, proxyHigh], [source]]);
+    expect(resolvedAddressSets).toEqual([[proxyHigh]]);
+  });
+
+  it('deduplicates voters resolving to the same source', async () => {
+    const { result, scoredAddressSets } = await scoreFixture({
+      addresses: [proxyHigh, proxyLow],
+      directScores: { [proxyHigh]: 0, [proxyLow]: 0 },
+      sourceByProxy: { [proxyHigh]: source, [proxyLow]: source },
+      sourceScores: { [source]: 12 }
+    });
+
+    expect(result).toEqual({ [proxyHigh]: 0, [proxyLow]: 12 });
+    expect(scoredAddressSets).toEqual([[proxyHigh, proxyLow], [source]]);
+  });
+
+  it('lets a direct source voter win over its proxy', async () => {
+    const { result } = await scoreFixture({
+      addresses: [source, proxyHigh],
+      directScores: { [source]: 12, [proxyHigh]: 0 },
+      sourceByProxy: { [proxyHigh]: source },
+      sourceScores: { [source]: 12 }
+    });
+
+    expect(result).toEqual({ [source]: 12, [proxyHigh]: 0 });
+  });
+});
+
+function address(byte: string): string {
+  return `0x${byte.repeat(20)}`;
+}
+
+async function scoreFixture({
+  addresses,
+  directScores = {},
+  sourceByProxy = {},
+  sourceScores = {}
+}) {
+  const scoredAddressSets: string[][] = [];
+  const resolvedAddressSets: string[][] = [];
+  let scoreCalls = 0;
+
+  const result = await scoreWithVotingProxy({
+    addresses,
+    scoreInner: async scoringAddresses => {
+      scoredAddressSets.push(scoringAddresses);
+      scoreCalls += 1;
+
+      return scoreCalls === 1 ? directScores : sourceScores;
+    },
+    resolveSources: async sourceCandidates => {
+      resolvedAddressSets.push(sourceCandidates);
+
+      return sourceByProxy;
+    }
+  });
+
+  return { result, scoredAddressSets, resolvedAddressSets };
+}


### PR DESCRIPTION
## Summary

- Add the `voting-proxy` Snapshot strategy to Score API.
- Score zero-VP proxy voters by calling `source()` and scoring that source address with configured inner strategies.
- Add manifest, schema, README, a live example, and focused unit tests for source remapping and deduplication.

## Why

This is for older multisigs that cannot upgrade to ERC-1271, implement native Snapshot contract voting, or move their staked position. With a small voting proxy, the multisig can approve an exact Snapshot vote hash while this strategy maps the proxy voter back to the multisig/source address that already holds voting power.

## Validation

- `npx --yes yarn@1.22.22 jest -i test/strategies/unit/voting-proxy.test.ts --config=jest.config.unit.ts`
- `npx --yes yarn@1.22.22 typecheck`
- `npx --yes yarn@1.22.22 test:strategy voting-proxy`
- `npx --yes yarn@1.22.22 lint`
- `npx --yes yarn@1.22.22 build`

Note: the deprecated `snapshot-strategies` repository is archived and read-only, so this targets the current `score-api` repository per its deprecation notice.
