### PR TITLE
Add voting proxy strategy

### DIFF
--- a/src/strategies/strategies/voting-proxy/README.md
+++ b/src/strategies/strategies/voting-proxy/README.md
@@ -1,7 +1,7 @@
 # voting-proxy
 
 Generic overriding strategy for older multisigs that cannot upgrade to
-ERC-1271 or move their staked position.
+ERC-1271 or change where their existing Snapshot voting power lives.
 
 The voter submits a Snapshot vote from a small ERC-1271 voting proxy. If that
 proxy has zero direct voting power, this strategy calls `source()` on the proxy,

--- a/src/strategies/strategies/voting-proxy/README.md
+++ b/src/strategies/strategies/voting-proxy/README.md
@@ -4,9 +4,11 @@ Generic overriding strategy for older multisigs that cannot upgrade to
 ERC-1271 or move their voting power.
 
 The voter submits a Snapshot vote from a small ERC-1271 voting proxy. If that
-proxy has zero direct voting power, this strategy calls `source()` on the proxy,
-scores the returned source address with the configured inner strategies, and
-returns that voting power under the original proxy voter.
+proxy has zero direct voting power, this strategy batch-calls `source()` on
+zero-VP proxies, scores the returned source address with the configured inner
+strategies, and returns that voting power under the original proxy voter.
+
+Reference contract and tests: https://github.com/orbs-network/voting-proxy
 
 If several proxy voters resolve to the same source, a direct source voter wins.
 Otherwise, the lowest proxy address wins deterministically and the other proxies

--- a/src/strategies/strategies/voting-proxy/README.md
+++ b/src/strategies/strategies/voting-proxy/README.md
@@ -1,8 +1,7 @@
 # voting-proxy
 
 Generic overriding strategy for older multisigs that cannot upgrade to
-ERC-1271, implement native Snapshot contract voting, or move their staked
-position.
+ERC-1271 or move their staked position.
 
 The voter submits a Snapshot vote from a small ERC-1271 voting proxy. If that
 proxy has zero direct voting power, this strategy calls `source()` on the proxy,

--- a/src/strategies/strategies/voting-proxy/README.md
+++ b/src/strategies/strategies/voting-proxy/README.md
@@ -1,7 +1,7 @@
 # voting-proxy
 
 Generic overriding strategy for older multisigs that cannot upgrade to
-ERC-1271 or change where their existing Snapshot voting power lives.
+ERC-1271 or change the address that holds their voting power.
 
 The voter submits a Snapshot vote from a small ERC-1271 voting proxy. If that
 proxy has zero direct voting power, this strategy calls `source()` on the proxy,

--- a/src/strategies/strategies/voting-proxy/README.md
+++ b/src/strategies/strategies/voting-proxy/README.md
@@ -3,17 +3,17 @@
 Generic overriding strategy for older multisigs that cannot upgrade to
 ERC-1271 or move their voting power.
 
-The voter submits a Snapshot vote from a small ERC-1271 voting proxy. If that
-proxy has zero direct voting power, this strategy batch-calls `source()` on
-zero-VP proxies, scores the returned source address with the configured inner
-strategies, and returns that voting power under the original proxy voter.
+The voter submits a Snapshot vote from a configured ERC-1271 voting proxy. If
+that proxy has zero direct voting power, this strategy batch-calls `source()` on
+configured zero-VP proxies, scores the returned source address with the
+configured inner strategies, and returns that voting power under the original
+proxy voter.
 
 Reference contract and tests: https://github.com/orbs-network/voting-proxy
 
-This strategy only maps voting power from `source()` to the proxy voter. It does
-not validate ERC-1271 signatures or prove that a voter is an Orbs voting proxy.
-Use it only with Snapshot signature validation against the proxy contract;
-pairing it with arbitrary `source()` contracts is unsafe.
+This strategy only honors `source()` for addresses listed in `proxies`. It does
+not validate ERC-1271 signatures itself, so use it with Snapshot signature
+validation against the configured proxy contracts.
 
 If several proxy voters resolve to the same source, a direct source voter with a
 positive score wins. Otherwise, the lowest proxy address wins deterministically
@@ -23,6 +23,7 @@ Here is an example of parameters:
 
 ```json
 {
+  "proxies": ["0x966885831bD5FdaAe28Fae45dB0B396E3135549c"],
   "strategies": [
     {
       "name": "erc20-balance-of",

--- a/src/strategies/strategies/voting-proxy/README.md
+++ b/src/strategies/strategies/voting-proxy/README.md
@@ -1,0 +1,32 @@
+# voting-proxy
+
+Generic overriding strategy for older multisigs that cannot upgrade to
+ERC-1271, implement native Snapshot contract voting, or move their staked
+position.
+
+The voter submits a Snapshot vote from a small ERC-1271 voting proxy. If that
+proxy has zero direct voting power, this strategy calls `source()` on the proxy,
+scores the returned source address with the configured inner strategies, and
+returns that voting power under the original proxy voter.
+
+If several proxy voters resolve to the same source, a direct source voter wins.
+Otherwise, the lowest proxy address wins deterministically and the other proxies
+return `0`.
+
+Here is an example of parameters:
+
+```json
+{
+  "strategies": [
+    {
+      "name": "erc20-balance-of",
+      "network": "1",
+      "params": {
+        "address": "0xToken",
+        "symbol": "TOKEN",
+        "decimals": 18
+      }
+    }
+  ]
+}
+```

--- a/src/strategies/strategies/voting-proxy/README.md
+++ b/src/strategies/strategies/voting-proxy/README.md
@@ -1,7 +1,7 @@
 # voting-proxy
 
 Generic overriding strategy for older multisigs that cannot upgrade to
-ERC-1271 or change the address that holds their voting power.
+ERC-1271 or move their voting power.
 
 The voter submits a Snapshot vote from a small ERC-1271 voting proxy. If that
 proxy has zero direct voting power, this strategy calls `source()` on the proxy,

--- a/src/strategies/strategies/voting-proxy/README.md
+++ b/src/strategies/strategies/voting-proxy/README.md
@@ -3,17 +3,17 @@
 Generic overriding strategy for older multisigs that cannot upgrade to
 ERC-1271 or move their voting power.
 
-The voter submits a Snapshot vote from a configured ERC-1271 voting proxy. If
-that proxy has zero direct voting power, this strategy batch-calls `source()` on
-configured zero-VP proxies, scores the returned source address with the
+The voter submits a Snapshot vote from an ERC-1271 voting proxy created by the
+configured factory. If that proxy has zero direct voting power, this strategy
+batch-calls `factory.source(proxy)`, scores the returned source address with the
 configured inner strategies, and returns that voting power under the original
 proxy voter.
 
 Reference contract and tests: https://github.com/orbs-network/voting-proxy
 
-This strategy only honors `source()` for addresses listed in `proxies`. It does
+This strategy only honors sources returned by the configured factory. It does
 not validate ERC-1271 signatures itself, so use it with Snapshot signature
-validation against the configured proxy contracts.
+validation against the factory-created proxy contracts.
 
 If several proxy voters resolve to the same source, a direct source voter with a
 positive score wins. Otherwise, the lowest proxy address wins deterministically
@@ -23,7 +23,7 @@ Here is an example of parameters:
 
 ```json
 {
-  "proxies": ["0x966885831bD5FdaAe28Fae45dB0B396E3135549c"],
+  "factory": "0x1111111111111111111111111111111111111111",
   "strategies": [
     {
       "name": "erc20-balance-of",

--- a/src/strategies/strategies/voting-proxy/README.md
+++ b/src/strategies/strategies/voting-proxy/README.md
@@ -10,9 +10,14 @@ strategies, and returns that voting power under the original proxy voter.
 
 Reference contract and tests: https://github.com/orbs-network/voting-proxy
 
-If several proxy voters resolve to the same source, a direct source voter wins.
-Otherwise, the lowest proxy address wins deterministically and the other proxies
-return `0`.
+This strategy only maps voting power from `source()` to the proxy voter. It does
+not validate ERC-1271 signatures or prove that a voter is an Orbs voting proxy.
+Use it only with Snapshot signature validation against the proxy contract;
+pairing it with arbitrary `source()` contracts is unsafe.
+
+If several proxy voters resolve to the same source, a direct source voter with a
+positive score wins. Otherwise, the lowest proxy address wins deterministically
+and the other proxies return `0`.
 
 Here is an example of parameters:
 
@@ -23,9 +28,9 @@ Here is an example of parameters:
       "name": "erc20-balance-of",
       "network": "1",
       "params": {
-        "address": "0xToken",
-        "symbol": "TOKEN",
-        "decimals": 18
+        "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        "symbol": "USDC",
+        "decimals": 6
       }
     }
   ]

--- a/src/strategies/strategies/voting-proxy/examples.json
+++ b/src/strategies/strategies/voting-proxy/examples.json
@@ -4,6 +4,7 @@
     "strategy": {
       "name": "voting-proxy",
       "params": {
+        "proxies": ["0x966885831bD5FdaAe28Fae45dB0B396E3135549c"],
         "strategies": [
           {
             "name": "whitelist",

--- a/src/strategies/strategies/voting-proxy/examples.json
+++ b/src/strategies/strategies/voting-proxy/examples.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "Voting proxy with whitelisted source",
+    "strategy": {
+      "name": "voting-proxy",
+      "params": {
+        "strategies": [
+          {
+            "name": "whitelist",
+            "params": {
+              "symbol": "VP",
+              "addresses": ["0x135bb4cc36b5069Bc66130404F68dA593f9Fc2E8"]
+            }
+          }
+        ]
+      }
+    },
+    "network": "56",
+    "addresses": [
+      "0x966885831bD5FdaAe28Fae45dB0B396E3135549c",
+      "0x000000000000000000000000000000000000dEaD",
+      "0x2222222222222222222222222222222222222222"
+    ],
+    "snapshot": 105693000
+  }
+]

--- a/src/strategies/strategies/voting-proxy/examples.json
+++ b/src/strategies/strategies/voting-proxy/examples.json
@@ -1,16 +1,16 @@
 [
   {
-    "name": "Voting proxy with whitelisted source",
+    "name": "Voting proxy with factory",
     "strategy": {
       "name": "voting-proxy",
       "params": {
-        "proxies": ["0x966885831bD5FdaAe28Fae45dB0B396E3135549c"],
+        "factory": "0x1111111111111111111111111111111111111111",
         "strategies": [
           {
             "name": "whitelist",
             "params": {
               "symbol": "VP",
-              "addresses": ["0x135bb4cc36b5069Bc66130404F68dA593f9Fc2E8"]
+              "addresses": ["0x966885831bD5FdaAe28Fae45dB0B396E3135549c"]
             }
           }
         ]

--- a/src/strategies/strategies/voting-proxy/index.ts
+++ b/src/strategies/strategies/voting-proxy/index.ts
@@ -7,11 +7,11 @@ const MULTICALL3_ADDRESS = '0xcA11bde05977b3631167028862bE2a173976CA11';
 const MULTICALL3_ABI = [
   'function aggregate3(tuple(address target, bool allowFailure, bytes callData)[] calls) view returns (tuple(bool success, bytes returnData)[] returnData)'
 ];
-const SOURCE_ABI = ['function source() view returns (address)'];
+const FACTORY_ABI = ['function source(address proxy) view returns (address)'];
 const SOURCE_PAGE_SIZE = 200;
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 const multicallInterface = new Interface(MULTICALL3_ABI);
-const sourceInterface = new Interface(SOURCE_ABI);
+const factoryInterface = new Interface(FACTORY_ABI);
 
 type InnerStrategy = {
   name: string;
@@ -33,11 +33,10 @@ export async function strategy(
   if (!Array.isArray(strategies) || !strategies.length) {
     throw new Error('voting-proxy requires at least one inner strategy');
   }
-  const proxies = options?.proxies;
-  if (!Array.isArray(proxies) || !proxies.length) {
-    throw new Error('voting-proxy requires at least one proxy');
+  const factory = options?.factory;
+  if (typeof factory !== 'string') {
+    throw new Error('voting-proxy requires a factory');
   }
-  const proxyKeys = new Set(proxies.map(addressKey));
 
   return scoreWithVotingProxy({
     addresses,
@@ -51,11 +50,7 @@ export async function strategy(
         snapshot
       ),
     resolveSources: candidates =>
-      resolveSources(
-        provider,
-        candidates.filter(address => proxyKeys.has(addressKey(address))),
-        snapshot
-      )
+      resolveSources(provider, factory, candidates, snapshot)
   });
 }
 
@@ -88,12 +83,18 @@ async function scoreStrategies(
 
 async function resolveSources(
   provider,
+  factory: string,
   addresses: string[],
   snapshot: Snapshot
 ): Promise<Record<string, string>> {
   if (!provider?.call) return {};
   const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
-  const sources = await callSourceMulticall(provider, addresses, blockTag);
+  const sources = await callSourceMulticall(
+    provider,
+    factory,
+    addresses,
+    blockTag
+  );
 
   const entries = addresses.map((address, i) => {
     const source = normalizeSource(sources[i]);
@@ -114,6 +115,7 @@ function normalizeSource(value: unknown): string | undefined {
 
 async function callSourceMulticall(
   provider,
+  factory: string,
   addresses: string[],
   blockTag: number | 'latest'
 ): Promise<unknown[]> {
@@ -122,6 +124,7 @@ async function callSourceMulticall(
     Array.from({ length: pages }, (_, i) =>
       callSourceMulticallPage(
         provider,
+        factory,
         addresses.slice(i * SOURCE_PAGE_SIZE, (i + 1) * SOURCE_PAGE_SIZE),
         blockTag
       )
@@ -133,6 +136,7 @@ async function callSourceMulticall(
 
 async function callSourceMulticallPage(
   provider,
+  factory: string,
   addresses: string[],
   blockTag: number | 'latest'
 ): Promise<unknown[]> {
@@ -141,9 +145,9 @@ async function callSourceMulticallPage(
       to: MULTICALL3_ADDRESS,
       data: multicallInterface.encodeFunctionData('aggregate3', [
         addresses.map(address => [
-          address.toLowerCase(),
+          factory.toLowerCase(),
           true,
-          sourceInterface.encodeFunctionData('source', [])
+          factoryInterface.encodeFunctionData('source', [address.toLowerCase()])
         ])
       ])
     },
@@ -164,12 +168,8 @@ function decodeSourceResult(result): string | undefined {
   if (!success || typeof returnData !== 'string') return undefined;
 
   try {
-    return sourceInterface.decodeFunctionResult('source', returnData)[0];
+    return factoryInterface.decodeFunctionResult('source', returnData)[0];
   } catch {
     return undefined;
   }
-}
-
-function addressKey(address: string): string {
-  return address.toLowerCase();
 }

--- a/src/strategies/strategies/voting-proxy/index.ts
+++ b/src/strategies/strategies/voting-proxy/index.ts
@@ -1,14 +1,16 @@
 import { Interface } from '@ethersproject/abi';
-import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import type { Snapshot } from '../../types';
+import { getScoresDirect } from '../../utils';
 import { scoreWithVotingProxy } from './proxyScoring';
 
-const MULTICALL_ABI = [
-  'function aggregate(tuple(address target, bytes callData)[] calls) view returns (uint256 blockNumber, bytes[] returnData)'
+const MULTICALL3_ADDRESS = '0xcA11bde05977b3631167028862bE2a173976CA11';
+const MULTICALL3_ABI = [
+  'function aggregate3(tuple(address target, bool allowFailure, bytes callData)[] calls) view returns (tuple(bool success, bytes returnData)[] returnData)'
 ];
 const SOURCE_ABI = ['function source() view returns (address)'];
+const SOURCE_PAGE_SIZE = 200;
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
-const multicallInterface = new Interface(MULTICALL_ABI);
+const multicallInterface = new Interface(MULTICALL3_ABI);
 const sourceInterface = new Interface(SOURCE_ABI);
 
 type InnerStrategy = {
@@ -43,8 +45,7 @@ export async function strategy(
         strategies,
         snapshot
       ),
-    resolveSources: proxies =>
-      resolveSources(network, provider, proxies, snapshot)
+    resolveSources: proxies => resolveSources(provider, proxies, snapshot)
   });
 }
 
@@ -57,7 +58,7 @@ async function scoreStrategies(
   snapshot: Snapshot
 ): Promise<Record<string, number>> {
   const totals = Object.fromEntries(addresses.map(address => [address, 0]));
-  const scoresByStrategy = await getInnerScores(
+  const scoresByStrategy = await getScoresDirect(
     space,
     strategies,
     network,
@@ -75,40 +76,15 @@ async function scoreStrategies(
   return totals;
 }
 
-async function getInnerScores(
-  space: string,
-  strategies: InnerStrategy[],
-  network: string,
-  provider,
-  addresses: string[],
-  snapshot: Snapshot
-): Promise<Record<string, number>[]> {
-  const { getScoresDirect } = await import('../../utils');
-  return getScoresDirect(
-    space,
-    strategies,
-    network,
-    provider,
-    addresses,
-    snapshot
-  );
-}
-
 async function resolveSources(
-  network: string,
   provider,
   addresses: string[],
   snapshot: Snapshot
 ): Promise<Record<string, string>> {
-  if (!provider) return {};
+  if (!provider?.call) return {};
   const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
-
-  let sources: unknown[];
-  try {
-    sources = await callSourceMulticall(network, provider, addresses, blockTag);
-  } catch {
-    return {};
-  }
+  // Snapshot signature validation must gate which proxy votes are accepted.
+  const sources = await callSourceMulticall(provider, addresses, blockTag);
 
   const entries = addresses.map((address, i) => {
     const source = normalizeSource(sources[i]);
@@ -128,20 +104,36 @@ function normalizeSource(value: unknown): string | undefined {
 }
 
 async function callSourceMulticall(
-  network: string,
   provider,
   addresses: string[],
   blockTag: number | 'latest'
 ): Promise<unknown[]> {
-  const multicallAddress = getMulticallAddress(network);
-  if (!multicallAddress) return [];
+  const pages = Math.ceil(addresses.length / SOURCE_PAGE_SIZE);
+  const results = await Promise.all(
+    Array.from({ length: pages }, (_, i) =>
+      callSourceMulticallPage(
+        provider,
+        addresses.slice(i * SOURCE_PAGE_SIZE, (i + 1) * SOURCE_PAGE_SIZE),
+        blockTag
+      )
+    )
+  );
 
+  return results.flat();
+}
+
+async function callSourceMulticallPage(
+  provider,
+  addresses: string[],
+  blockTag: number | 'latest'
+): Promise<unknown[]> {
   const result = await provider.call(
     {
-      to: multicallAddress,
-      data: multicallInterface.encodeFunctionData('aggregate', [
+      to: MULTICALL3_ADDRESS,
+      data: multicallInterface.encodeFunctionData('aggregate3', [
         addresses.map(address => [
           address.toLowerCase(),
+          true,
           sourceInterface.encodeFunctionData('source', [])
         ])
       ])
@@ -149,23 +141,22 @@ async function callSourceMulticall(
     blockTag
   );
 
-  const [, returnData] = multicallInterface.decodeFunctionResult(
-    'aggregate',
+  const [returnData] = multicallInterface.decodeFunctionResult(
+    'aggregate3',
     result
-  );
+  ) as [unknown[]];
 
   return returnData.map(decodeSourceResult);
 }
 
-function decodeSourceResult(result: string): string | undefined {
+function decodeSourceResult(result): string | undefined {
+  const success = result.success ?? result[0];
+  const returnData = result.returnData ?? result[1];
+  if (!success || typeof returnData !== 'string') return undefined;
+
   try {
-    return sourceInterface.decodeFunctionResult('source', result)[0];
+    return sourceInterface.decodeFunctionResult('source', returnData)[0];
   } catch {
     return undefined;
   }
-}
-
-function getMulticallAddress(network: string): string | undefined {
-  return (networks as Record<string, { multicall?: string }>)[network]
-    ?.multicall;
 }

--- a/src/strategies/strategies/voting-proxy/index.ts
+++ b/src/strategies/strategies/voting-proxy/index.ts
@@ -1,9 +1,15 @@
-import { getScoresDirect } from '../../utils';
+import { Interface } from '@ethersproject/abi';
+import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import type { Snapshot } from '../../types';
 import { scoreWithVotingProxy } from './proxyScoring';
 
-const SOURCE_SELECTOR = '0x67e828bf';
+const MULTICALL_ABI = [
+  'function aggregate(tuple(address target, bytes callData)[] calls) view returns (uint256 blockNumber, bytes[] returnData)'
+];
+const SOURCE_ABI = ['function source() view returns (address)'];
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+const multicallInterface = new Interface(MULTICALL_ABI);
+const sourceInterface = new Interface(SOURCE_ABI);
 
 type InnerStrategy = {
   name: string;
@@ -37,7 +43,8 @@ export async function strategy(
         strategies,
         snapshot
       ),
-    resolveSources: proxies => resolveSources(provider, proxies, snapshot)
+    resolveSources: proxies =>
+      resolveSources(network, provider, proxies, snapshot)
   });
 }
 
@@ -50,7 +57,7 @@ async function scoreStrategies(
   snapshot: Snapshot
 ): Promise<Record<string, number>> {
   const totals = Object.fromEntries(addresses.map(address => [address, 0]));
-  const scoresByStrategy = await getScoresDirect(
+  const scoresByStrategy = await getInnerScores(
     space,
     strategies,
     network,
@@ -68,37 +75,97 @@ async function scoreStrategies(
   return totals;
 }
 
+async function getInnerScores(
+  space: string,
+  strategies: InnerStrategy[],
+  network: string,
+  provider,
+  addresses: string[],
+  snapshot: Snapshot
+): Promise<Record<string, number>[]> {
+  const { getScoresDirect } = await import('../../utils');
+  return getScoresDirect(
+    space,
+    strategies,
+    network,
+    provider,
+    addresses,
+    snapshot
+  );
+}
+
 async function resolveSources(
+  network: string,
   provider,
   addresses: string[],
   snapshot: Snapshot
 ): Promise<Record<string, string>> {
-  if (!provider?.call) return {};
-
+  if (!provider) return {};
   const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
-  const entries = await Promise.all(
-    addresses.map(async address => {
-      try {
-        const source = decodeSource(
-          await provider.call({ to: address, data: SOURCE_SELECTOR }, blockTag)
-        );
 
-        return source && source !== ZERO_ADDRESS
-          ? [address, source]
-          : undefined;
-      } catch {
-        return undefined;
-      }
-    })
-  );
+  let sources: unknown[];
+  try {
+    sources = await callSourceMulticall(network, provider, addresses, blockTag);
+  } catch {
+    return {};
+  }
+
+  const entries = addresses.map((address, i) => {
+    const source = normalizeSource(sources[i]);
+    return source && source !== ZERO_ADDRESS ? [address, source] : undefined;
+  });
 
   return Object.fromEntries(
     entries.filter((entry): entry is [string, string] => !!entry)
   );
 }
 
-function decodeSource(result: string): string | undefined {
-  return /^0x[0-9a-fA-F]{64}$/.test(result)
-    ? `0x${result.slice(26).toLowerCase()}`
+function normalizeSource(value: unknown): string | undefined {
+  const source = Array.isArray(value) ? value[0] : value;
+  return typeof source === 'string' && /^0x[0-9a-fA-F]{40}$/.test(source)
+    ? source.toLowerCase()
     : undefined;
+}
+
+async function callSourceMulticall(
+  network: string,
+  provider,
+  addresses: string[],
+  blockTag: number | 'latest'
+): Promise<unknown[]> {
+  const multicallAddress = getMulticallAddress(network);
+  if (!multicallAddress) return [];
+
+  const result = await provider.call(
+    {
+      to: multicallAddress,
+      data: multicallInterface.encodeFunctionData('aggregate', [
+        addresses.map(address => [
+          address.toLowerCase(),
+          sourceInterface.encodeFunctionData('source', [])
+        ])
+      ])
+    },
+    blockTag
+  );
+
+  const [, returnData] = multicallInterface.decodeFunctionResult(
+    'aggregate',
+    result
+  );
+
+  return returnData.map(decodeSourceResult);
+}
+
+function decodeSourceResult(result: string): string | undefined {
+  try {
+    return sourceInterface.decodeFunctionResult('source', result)[0];
+  } catch {
+    return undefined;
+  }
+}
+
+function getMulticallAddress(network: string): string | undefined {
+  return (networks as Record<string, { multicall?: string }>)[network]
+    ?.multicall;
 }

--- a/src/strategies/strategies/voting-proxy/index.ts
+++ b/src/strategies/strategies/voting-proxy/index.ts
@@ -33,6 +33,11 @@ export async function strategy(
   if (!Array.isArray(strategies) || !strategies.length) {
     throw new Error('voting-proxy requires at least one inner strategy');
   }
+  const proxies = options?.proxies;
+  if (!Array.isArray(proxies) || !proxies.length) {
+    throw new Error('voting-proxy requires at least one proxy');
+  }
+  const proxyKeys = new Set(proxies.map(addressKey));
 
   return scoreWithVotingProxy({
     addresses,
@@ -45,7 +50,12 @@ export async function strategy(
         strategies,
         snapshot
       ),
-    resolveSources: proxies => resolveSources(provider, proxies, snapshot)
+    resolveSources: candidates =>
+      resolveSources(
+        provider,
+        candidates.filter(address => proxyKeys.has(addressKey(address))),
+        snapshot
+      )
   });
 }
 
@@ -83,7 +93,6 @@ async function resolveSources(
 ): Promise<Record<string, string>> {
   if (!provider?.call) return {};
   const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
-  // Snapshot signature validation must gate which proxy votes are accepted.
   const sources = await callSourceMulticall(provider, addresses, blockTag);
 
   const entries = addresses.map((address, i) => {
@@ -159,4 +168,8 @@ function decodeSourceResult(result): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+function addressKey(address: string): string {
+  return address.toLowerCase();
 }

--- a/src/strategies/strategies/voting-proxy/index.ts
+++ b/src/strategies/strategies/voting-proxy/index.ts
@@ -1,0 +1,104 @@
+import { getScoresDirect } from '../../utils';
+import type { Snapshot } from '../../types';
+import { scoreWithVotingProxy } from './proxyScoring';
+
+const SOURCE_SELECTOR = '0x67e828bf';
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+type InnerStrategy = {
+  name: string;
+  network?: string;
+  params?: Record<string, unknown>;
+};
+
+export const supportedProtocols = ['evm'];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot: Snapshot
+): Promise<Record<string, number>> {
+  const strategies = options?.strategies;
+  if (!Array.isArray(strategies) || !strategies.length) {
+    throw new Error('voting-proxy requires at least one inner strategy');
+  }
+
+  return scoreWithVotingProxy({
+    addresses,
+    scoreInner: scoringAddresses =>
+      scoreStrategies(
+        space,
+        network,
+        provider,
+        scoringAddresses,
+        strategies,
+        snapshot
+      ),
+    resolveSources: proxies => resolveSources(provider, proxies, snapshot)
+  });
+}
+
+async function scoreStrategies(
+  space: string,
+  network: string,
+  provider,
+  addresses: string[],
+  strategies: InnerStrategy[],
+  snapshot: Snapshot
+): Promise<Record<string, number>> {
+  const totals = Object.fromEntries(addresses.map(address => [address, 0]));
+  const scoresByStrategy = await getScoresDirect(
+    space,
+    strategies,
+    network,
+    provider,
+    addresses,
+    snapshot
+  );
+
+  for (const scores of scoresByStrategy) {
+    for (const [address, score] of Object.entries(scores)) {
+      totals[address] = (totals[address] ?? 0) + Number(score);
+    }
+  }
+
+  return totals;
+}
+
+async function resolveSources(
+  provider,
+  addresses: string[],
+  snapshot: Snapshot
+): Promise<Record<string, string>> {
+  if (!provider?.call) return {};
+
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+  const entries = await Promise.all(
+    addresses.map(async address => {
+      try {
+        const source = decodeSource(
+          await provider.call({ to: address, data: SOURCE_SELECTOR }, blockTag)
+        );
+
+        return source && source !== ZERO_ADDRESS
+          ? [address, source]
+          : undefined;
+      } catch {
+        return undefined;
+      }
+    })
+  );
+
+  return Object.fromEntries(
+    entries.filter((entry): entry is [string, string] => !!entry)
+  );
+}
+
+function decodeSource(result: string): string | undefined {
+  return /^0x[0-9a-fA-F]{64}$/.test(result)
+    ? `0x${result.slice(26).toLowerCase()}`
+    : undefined;
+}

--- a/src/strategies/strategies/voting-proxy/manifest.json
+++ b/src/strategies/strategies/voting-proxy/manifest.json
@@ -1,0 +1,6 @@
+{
+  "name": "Voting Proxy",
+  "author": "orbs-network",
+  "version": "0.1.0",
+  "overriding": true
+}

--- a/src/strategies/strategies/voting-proxy/proxyScoring.ts
+++ b/src/strategies/strategies/voting-proxy/proxyScoring.ts
@@ -1,0 +1,96 @@
+type ScoreMap = Record<string, number>;
+type SourceMap = Record<string, string>;
+
+export async function scoreWithVotingProxy({
+  addresses,
+  scoreInner,
+  resolveSources
+}: {
+  addresses: string[];
+  scoreInner: (addresses: string[]) => Promise<ScoreMap>;
+  resolveSources: (addresses: string[]) => Promise<SourceMap>;
+}): Promise<ScoreMap> {
+  const directScores = normalizeAddressKeys(await scoreInner(addresses));
+  const proxyCandidates = addresses.filter(
+    address => (directScores[addressKey(address)] ?? 0) === 0
+  );
+  const sourcesByProxy = normalizeAddressKeys(
+    proxyCandidates.length ? await resolveSources(proxyCandidates) : {}
+  );
+  const winningProxyBySource = winnersBySource(
+    proxyCandidates,
+    sourcesByProxy,
+    new Set(addresses.map(addressKey))
+  );
+  const sources = Object.keys(winningProxyBySource);
+  const sourceScores = normalizeAddressKeys(
+    sources.length ? await scoreInner(sources) : {}
+  );
+
+  return Object.fromEntries(
+    addresses.map(address => [
+      address,
+      score(
+        address,
+        directScores,
+        sourcesByProxy,
+        winningProxyBySource,
+        sourceScores
+      )
+    ])
+  );
+}
+
+function winnersBySource(
+  proxies: string[],
+  sourcesByProxy: SourceMap,
+  voterKeys: Set<string>
+): SourceMap {
+  const winners: SourceMap = {};
+
+  for (const proxy of proxies) {
+    const source = sourcesByProxy[addressKey(proxy)];
+    const sourceKey = source && addressKey(source);
+    if (!sourceKey || voterKeys.has(sourceKey)) continue;
+
+    const proxyKey = addressKey(proxy);
+    if (!winners[sourceKey] || proxyKey < winners[sourceKey]) {
+      winners[sourceKey] = proxyKey;
+    }
+  }
+
+  return winners;
+}
+
+function score(
+  address: string,
+  directScores: ScoreMap,
+  sourcesByProxy: SourceMap,
+  sourceWinners: SourceMap,
+  sourceScores: ScoreMap
+): number {
+  const key = addressKey(address);
+  const directScore = directScores[key] ?? 0;
+  if (directScore !== 0) return directScore;
+
+  const source = sourcesByProxy[key];
+  if (!source) return 0;
+
+  const sourceKey = addressKey(source);
+  if (sourceWinners[sourceKey] !== key) return 0;
+
+  return sourceScores[sourceKey] ?? 0;
+}
+
+function normalizeAddressKeys<T>(values: Record<string, T>): Record<string, T> {
+  return Object.fromEntries(
+    Object.entries(values).map(([address, value]) => [
+      addressKey(address),
+      value
+    ])
+  );
+}
+
+function addressKey(address: string): string {
+  return address.toLowerCase();
+}

--- a/src/strategies/strategies/voting-proxy/proxyScoring.ts
+++ b/src/strategies/strategies/voting-proxy/proxyScoring.ts
@@ -20,7 +20,7 @@ export async function scoreWithVotingProxy({
   const winningProxyBySource = winnersBySource(
     proxyCandidates,
     sourcesByProxy,
-    new Set(addresses.map(addressKey))
+    directScores
   );
   const sources = Object.keys(winningProxyBySource);
   const sourceScores = normalizeAddressKeys(
@@ -44,14 +44,14 @@ export async function scoreWithVotingProxy({
 function winnersBySource(
   proxies: string[],
   sourcesByProxy: SourceMap,
-  voterKeys: Set<string>
+  directScores: ScoreMap
 ): SourceMap {
   const winners: SourceMap = {};
 
   for (const proxy of proxies) {
     const source = sourcesByProxy[addressKey(proxy)];
     const sourceKey = source && addressKey(source);
-    if (!sourceKey || voterKeys.has(sourceKey)) continue;
+    if (!sourceKey || (directScores[sourceKey] ?? 0) > 0) continue;
 
     const proxyKey = addressKey(proxy);
     if (!winners[sourceKey] || proxyKey < winners[sourceKey]) {

--- a/src/strategies/strategies/voting-proxy/schema.json
+++ b/src/strategies/strategies/voting-proxy/schema.json
@@ -6,6 +6,16 @@
       "title": "Strategy",
       "type": "object",
       "properties": {
+        "proxies": {
+          "type": "array",
+          "title": "Allowed proxy addresses",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^0x[a-fA-F0-9]{40}$"
+          }
+        },
         "strategies": {
           "type": "array",
           "title": "Inner strategies",
@@ -32,7 +42,7 @@
           }
         }
       },
-      "required": ["strategies"],
+      "required": ["proxies", "strategies"],
       "additionalProperties": false
     }
   }

--- a/src/strategies/strategies/voting-proxy/schema.json
+++ b/src/strategies/strategies/voting-proxy/schema.json
@@ -10,11 +10,15 @@
           "type": "array",
           "title": "Inner strategies",
           "minItems": 1,
+          "maxItems": 10,
           "items": {
             "type": "object",
             "properties": {
               "name": {
-                "type": "string"
+                "type": "string",
+                "not": {
+                  "const": "voting-proxy"
+                }
               },
               "network": {
                 "type": "string"

--- a/src/strategies/strategies/voting-proxy/schema.json
+++ b/src/strategies/strategies/voting-proxy/schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "strategies": {
+          "type": "array",
+          "title": "Inner strategies",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "network": {
+                "type": "string"
+              },
+              "params": {
+                "type": "object"
+              }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": ["strategies"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/strategies/strategies/voting-proxy/schema.json
+++ b/src/strategies/strategies/voting-proxy/schema.json
@@ -6,15 +6,10 @@
       "title": "Strategy",
       "type": "object",
       "properties": {
-        "proxies": {
-          "type": "array",
-          "title": "Allowed proxy addresses",
-          "minItems": 1,
-          "uniqueItems": true,
-          "items": {
-            "type": "string",
-            "pattern": "^0x[a-fA-F0-9]{40}$"
-          }
+        "factory": {
+          "type": "string",
+          "title": "Voting proxy factory",
+          "pattern": "^0x[a-fA-F0-9]{40}$"
         },
         "strategies": {
           "type": "array",
@@ -42,7 +37,7 @@
           }
         }
       },
-      "required": ["proxies", "strategies"],
+      "required": ["factory", "strategies"],
       "additionalProperties": false
     }
   }

--- a/test/strategies/unit/voting-proxy.test.ts
+++ b/test/strategies/unit/voting-proxy.test.ts
@@ -1,9 +1,29 @@
+import { Interface } from '@ethersproject/abi';
+import networks from '@snapshot-labs/snapshot.js/src/networks.json';
+import { strategy } from '../../../src/strategies/strategies/voting-proxy';
 import { scoreWithVotingProxy } from '../../../src/strategies/strategies/voting-proxy/proxyScoring';
+import { getScoresDirect } from '../../../src/strategies/utils';
+
+jest.mock('../../../src/strategies/utils', () => ({
+  getScoresDirect: jest.fn()
+}));
 
 const direct = address('10');
 const source = address('20');
 const proxyHigh = address('30');
 const proxyLow = address('11');
+const zeroAddress = address('00');
+const aggregateInterface = new Interface([
+  'function aggregate(tuple(address target, bytes callData)[] calls) view returns (uint256 blockNumber, bytes[] returnData)'
+]);
+const sourceInterface = new Interface([
+  'function source() view returns (address)'
+]);
+const sourceCalldata = sourceInterface.encodeFunctionData('source', []);
+type ProviderCallTx = { to: string; data: string };
+type ProviderCall = [ProviderCallTx, number | 'latest'];
+
+const getScoresDirectMock = jest.mocked(getScoresDirect);
 
 describe('voting-proxy scoring', () => {
   it('returns source voting power for a zero-vp proxy voter', async () => {
@@ -55,8 +75,116 @@ describe('voting-proxy scoring', () => {
   });
 });
 
+describe('voting-proxy strategy', () => {
+  beforeEach(() => {
+    getScoresDirectMock.mockReset();
+  });
+
+  it('resolves zero-vp proxy sources with one multicall at the snapshot block', async () => {
+    const provider = createProvider([source]);
+    getScoresDirectMock
+      .mockResolvedValueOnce([{ [proxyHigh]: 0 }])
+      .mockResolvedValueOnce([{ [source]: 12 }]);
+
+    await expect(scoreStrategy(provider, [proxyHigh], 123)).resolves.toEqual({
+      [proxyHigh]: 12
+    });
+    expect(provider.call).toHaveBeenCalledTimes(1);
+    expect(firstProviderCall(provider)[0].to).toBe(networks['1'].multicall);
+    expect(firstProviderCall(provider)[1]).toBe(123);
+    expect(decodeAggregateCalls(provider)).toEqual([
+      [proxyHigh.toLowerCase(), sourceCalldata]
+    ]);
+    expect(getScoresDirectMock).toHaveBeenNthCalledWith(
+      2,
+      'space',
+      [{ name: 'fixed-score' }],
+      '1',
+      provider,
+      [source],
+      123
+    );
+  });
+
+  it('keeps malformed and zero source results unresolved', async () => {
+    getScoresDirectMock.mockResolvedValueOnce([{ [proxyHigh]: 0 }]);
+    const provider = createProvider(['malformed', zeroAddress]);
+
+    await expect(
+      scoreStrategy(provider, [proxyHigh, proxyLow], 123)
+    ).resolves.toEqual({
+      [proxyHigh]: 0,
+      [proxyLow]: 0
+    });
+    expect(getScoresDirectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('decodes aggregate source results and uses latest for non-number snapshots', async () => {
+    const provider = createProvider([source]);
+    getScoresDirectMock
+      .mockResolvedValueOnce([{ [proxyHigh]: 0 }])
+      .mockResolvedValueOnce([{ [source]: 12 }]);
+
+    await expect(
+      scoreStrategy(provider, [proxyHigh], 'latest')
+    ).resolves.toEqual({
+      [proxyHigh]: 12
+    });
+    expect(firstProviderCall(provider)[1]).toBe('latest');
+  });
+
+  it('treats failed multicalls and missing providers as unresolved sources', async () => {
+    getScoresDirectMock.mockResolvedValue([{ [proxyHigh]: 0 }]);
+    const provider = createProvider([], new Error('not a contract'));
+
+    await expect(scoreStrategy(provider, [proxyHigh], 123)).resolves.toEqual({
+      [proxyHigh]: 0
+    });
+    await expect(scoreStrategy(null, [proxyHigh], 123)).resolves.toEqual({
+      [proxyHigh]: 0
+    });
+  });
+});
+
 function address(byte: string): string {
   return `0x${byte.repeat(20)}`;
+}
+
+function createProvider(sourceResults: Array<string>, error?: Error) {
+  return {
+    call: jest.fn<Promise<string>, ProviderCall>(async () => {
+      if (error) throw error;
+
+      return aggregateInterface.encodeFunctionResult('aggregate', [
+        123,
+        sourceResults.map(encodeSourceResult)
+      ]);
+    })
+  };
+}
+
+function encodeSourceResult(sourceResult: string): string {
+  if (sourceResult === 'malformed') return '0x1234';
+  return sourceInterface.encodeFunctionResult('source', [sourceResult]);
+}
+
+function firstProviderCall(
+  provider: ReturnType<typeof createProvider>
+): ProviderCall {
+  return provider.call.mock.calls[0] as ProviderCall;
+}
+
+function decodeAggregateCalls(
+  provider: ReturnType<typeof createProvider>
+): string[][] {
+  const calls = aggregateInterface.decodeFunctionData(
+    'aggregate',
+    firstProviderCall(provider)[0].data
+  )[0];
+
+  return Array.from(calls as unknown as Array<[string, string]>).map(
+    ([target, data]) => [target, data]
+  );
 }
 
 async function scoreFixture({
@@ -85,4 +213,15 @@ async function scoreFixture({
   });
 
   return { result, scoredAddressSets, resolvedAddressSets };
+}
+
+function scoreStrategy(provider, addresses: string[], snapshot) {
+  return strategy(
+    'space',
+    '1',
+    provider,
+    addresses,
+    { strategies: [{ name: 'fixed-score' }] },
+    snapshot
+  );
 }

--- a/test/strategies/unit/voting-proxy.test.ts
+++ b/test/strategies/unit/voting-proxy.test.ts
@@ -1,5 +1,4 @@
 import { Interface } from '@ethersproject/abi';
-import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import { strategy } from '../../../src/strategies/strategies/voting-proxy';
 import { scoreWithVotingProxy } from '../../../src/strategies/strategies/voting-proxy/proxyScoring';
 import { getScoresDirect } from '../../../src/strategies/utils';
@@ -13,8 +12,10 @@ const source = address('20');
 const proxyHigh = address('30');
 const proxyLow = address('11');
 const zeroAddress = address('00');
-const aggregateInterface = new Interface([
-  'function aggregate(tuple(address target, bytes callData)[] calls) view returns (uint256 blockNumber, bytes[] returnData)'
+const multicall3Address = '0xcA11bde05977b3631167028862bE2a173976CA11';
+const sourcePageSize = 200;
+const aggregate3Interface = new Interface([
+  'function aggregate3(tuple(address target, bool allowFailure, bytes callData)[] calls) view returns (tuple(bool success, bytes returnData)[] returnData)'
 ]);
 const sourceInterface = new Interface([
   'function source() view returns (address)'
@@ -22,6 +23,7 @@ const sourceInterface = new Interface([
 const sourceCalldata = sourceInterface.encodeFunctionData('source', []);
 type ProviderCallTx = { to: string; data: string };
 type ProviderCall = [ProviderCallTx, number | 'latest'];
+type SourceResult = string | 'failed' | 'malformed';
 
 const getScoresDirectMock = jest.mocked(getScoresDirect);
 
@@ -73,6 +75,17 @@ describe('voting-proxy scoring', () => {
 
     expect(result).toEqual({ [source]: 12, [proxyHigh]: 0 });
   });
+
+  it('lets a proxy use the source score when the direct source voter has no score', async () => {
+    const { result } = await scoreFixture({
+      addresses: [source, proxyHigh],
+      directScores: { [source]: 0, [proxyHigh]: 0 },
+      sourceByProxy: { [proxyHigh]: source },
+      sourceScores: { [source]: 12 }
+    });
+
+    expect(result).toEqual({ [source]: 0, [proxyHigh]: 12 });
+  });
 });
 
 describe('voting-proxy strategy', () => {
@@ -80,7 +93,7 @@ describe('voting-proxy strategy', () => {
     getScoresDirectMock.mockReset();
   });
 
-  it('resolves zero-vp proxy sources with one multicall at the snapshot block', async () => {
+  it('resolves zero-vp proxy sources with multicall3 allowFailure at the snapshot block', async () => {
     const provider = createProvider([source]);
     getScoresDirectMock
       .mockResolvedValueOnce([{ [proxyHigh]: 0 }])
@@ -90,10 +103,10 @@ describe('voting-proxy strategy', () => {
       [proxyHigh]: 12
     });
     expect(provider.call).toHaveBeenCalledTimes(1);
-    expect(firstProviderCall(provider)[0].to).toBe(networks['1'].multicall);
+    expect(firstProviderCall(provider)[0].to).toBe(multicall3Address);
     expect(firstProviderCall(provider)[1]).toBe(123);
-    expect(decodeAggregateCalls(provider)).toEqual([
-      [proxyHigh.toLowerCase(), sourceCalldata]
+    expect(decodeAggregate3Calls(provider)).toEqual([
+      [proxyHigh.toLowerCase(), true, sourceCalldata]
     ]);
     expect(getScoresDirectMock).toHaveBeenNthCalledWith(
       2,
@@ -104,6 +117,51 @@ describe('voting-proxy strategy', () => {
       [source],
       123
     );
+  });
+
+  it('keeps successful source results when other multicall3 calls fail', async () => {
+    const provider = createProvider(['failed', source]);
+    getScoresDirectMock
+      .mockResolvedValueOnce([{ [proxyHigh]: 0, [proxyLow]: 0 }])
+      .mockResolvedValueOnce([{ [source]: 12 }]);
+
+    await expect(
+      scoreStrategy(provider, [proxyHigh, proxyLow], 123)
+    ).resolves.toEqual({
+      [proxyHigh]: 0,
+      [proxyLow]: 12
+    });
+    expect(getScoresDirectMock).toHaveBeenNthCalledWith(
+      2,
+      'space',
+      [{ name: 'fixed-score' }],
+      '1',
+      provider,
+      [source],
+      123
+    );
+  });
+
+  it('pages source lookups through multicall3', async () => {
+    const proxies = Array.from({ length: sourcePageSize + 1 }, (_, i) =>
+      numberedAddress(i + 1)
+    );
+    const sources = proxies.map((_, i) => numberedAddress(i + 1000));
+    const directScores = Object.fromEntries(proxies.map(proxy => [proxy, 0]));
+    const sourceScores = Object.fromEntries(
+      sources.map(sourceAddress => [sourceAddress, 1])
+    );
+    const provider = createProvider(sources);
+
+    getScoresDirectMock
+      .mockResolvedValueOnce([directScores])
+      .mockResolvedValueOnce([sourceScores]);
+
+    await scoreStrategy(provider, proxies, 123);
+
+    expect(provider.call).toHaveBeenCalledTimes(2);
+    expect(decodeAggregate3Calls(provider, 0)).toHaveLength(sourcePageSize);
+    expect(decodeAggregate3Calls(provider, 1)).toHaveLength(1);
   });
 
   it('keeps malformed and zero source results unresolved', async () => {
@@ -119,7 +177,7 @@ describe('voting-proxy strategy', () => {
     expect(getScoresDirectMock).toHaveBeenCalledTimes(1);
   });
 
-  it('decodes aggregate source results and uses latest for non-number snapshots', async () => {
+  it('decodes aggregate3 source results and uses latest for non-number snapshots', async () => {
     const provider = createProvider([source]);
     getScoresDirectMock
       .mockResolvedValueOnce([{ [proxyHigh]: 0 }])
@@ -133,13 +191,18 @@ describe('voting-proxy strategy', () => {
     expect(firstProviderCall(provider)[1]).toBe('latest');
   });
 
-  it('treats failed multicalls and missing providers as unresolved sources', async () => {
+  it('propagates multicall3 transport failures', async () => {
     getScoresDirectMock.mockResolvedValue([{ [proxyHigh]: 0 }]);
-    const provider = createProvider([], new Error('not a contract'));
+    const provider = createProvider([], new Error('rpc failed'));
 
-    await expect(scoreStrategy(provider, [proxyHigh], 123)).resolves.toEqual({
-      [proxyHigh]: 0
-    });
+    await expect(scoreStrategy(provider, [proxyHigh], 123)).rejects.toThrow(
+      'rpc failed'
+    );
+  });
+
+  it('treats missing providers as unresolved sources', async () => {
+    getScoresDirectMock.mockResolvedValue([{ [proxyHigh]: 0 }]);
+
     await expect(scoreStrategy(null, [proxyHigh], 123)).resolves.toEqual({
       [proxyHigh]: 0
     });
@@ -150,21 +213,41 @@ function address(byte: string): string {
   return `0x${byte.repeat(20)}`;
 }
 
-function createProvider(sourceResults: Array<string>, error?: Error) {
+function numberedAddress(value: number): string {
+  return `0x${value.toString(16).padStart(40, '0')}`;
+}
+
+function createProvider(sourceResults: SourceResult[], error?: Error) {
+  let resultIndex = 0;
+
   return {
-    call: jest.fn<Promise<string>, ProviderCall>(async () => {
+    call: jest.fn<Promise<string>, ProviderCall>(async ({ data }) => {
       if (error) throw error;
 
-      return aggregateInterface.encodeFunctionResult('aggregate', [
-        123,
-        sourceResults.map(encodeSourceResult)
+      const calls = aggregate3Interface.decodeFunctionData(
+        'aggregate3',
+        data
+      )[0];
+      const pageResults = sourceResults.slice(
+        resultIndex,
+        resultIndex + calls.length
+      );
+      resultIndex += calls.length;
+
+      return aggregate3Interface.encodeFunctionResult('aggregate3', [
+        pageResults.map(encodeAggregate3Result)
       ]);
     })
   };
 }
 
+function encodeAggregate3Result(sourceResult: SourceResult): [boolean, string] {
+  if (sourceResult === 'failed') return [false, '0x'];
+  if (sourceResult === 'malformed') return [true, '0x1234'];
+  return [true, encodeSourceResult(sourceResult)];
+}
+
 function encodeSourceResult(sourceResult: string): string {
-  if (sourceResult === 'malformed') return '0x1234';
   return sourceInterface.encodeFunctionResult('source', [sourceResult]);
 }
 
@@ -174,16 +257,17 @@ function firstProviderCall(
   return provider.call.mock.calls[0] as ProviderCall;
 }
 
-function decodeAggregateCalls(
-  provider: ReturnType<typeof createProvider>
-): string[][] {
-  const calls = aggregateInterface.decodeFunctionData(
-    'aggregate',
-    firstProviderCall(provider)[0].data
+function decodeAggregate3Calls(
+  provider: ReturnType<typeof createProvider>,
+  callIndex = 0
+): Array<[string, boolean, string]> {
+  const calls = aggregate3Interface.decodeFunctionData(
+    'aggregate3',
+    (provider.call.mock.calls[callIndex] as ProviderCall)[0].data
   )[0];
 
-  return Array.from(calls as unknown as Array<[string, string]>).map(
-    ([target, data]) => [target, data]
+  return Array.from(calls as unknown as Array<[string, boolean, string]>).map(
+    ([target, allowFailure, data]) => [target, allowFailure, data]
   );
 }
 

--- a/test/strategies/unit/voting-proxy.test.ts
+++ b/test/strategies/unit/voting-proxy.test.ts
@@ -93,6 +93,19 @@ describe('voting-proxy strategy', () => {
     getScoresDirectMock.mockReset();
   });
 
+  it('requires at least one configured proxy', async () => {
+    await expect(
+      strategy(
+        'space',
+        '1',
+        null,
+        [proxyHigh],
+        { strategies: [{ name: 'fixed-score' }] },
+        123
+      )
+    ).rejects.toThrow('voting-proxy requires at least one proxy');
+  });
+
   it('resolves zero-vp proxy sources with multicall3 allowFailure at the snapshot block', async () => {
     const provider = createProvider([source]);
     getScoresDirectMock
@@ -117,6 +130,25 @@ describe('voting-proxy strategy', () => {
       [source],
       123
     );
+  });
+
+  it('ignores source lookups from voters outside the configured proxies', async () => {
+    const provider = createProvider([source]);
+    getScoresDirectMock
+      .mockResolvedValueOnce([{ [proxyHigh]: 0, [proxyLow]: 0 }])
+      .mockResolvedValueOnce([{ [source]: 12 }]);
+
+    await expect(
+      scoreStrategy(provider, [proxyHigh, proxyLow], 123, {
+        proxies: [proxyLow]
+      })
+    ).resolves.toEqual({
+      [proxyHigh]: 0,
+      [proxyLow]: 12
+    });
+    expect(decodeAggregate3Calls(provider)).toEqual([
+      [proxyLow.toLowerCase(), true, sourceCalldata]
+    ]);
   });
 
   it('keeps successful source results when other multicall3 calls fail', async () => {
@@ -299,13 +331,18 @@ async function scoreFixture({
   return { result, scoredAddressSets, resolvedAddressSets };
 }
 
-function scoreStrategy(provider, addresses: string[], snapshot) {
+function scoreStrategy(
+  provider,
+  addresses: string[],
+  snapshot,
+  options: Record<string, unknown> = {}
+) {
   return strategy(
     'space',
     '1',
     provider,
     addresses,
-    { strategies: [{ name: 'fixed-score' }] },
+    { proxies: addresses, strategies: [{ name: 'fixed-score' }], ...options },
     snapshot
   );
 }

--- a/test/strategies/unit/voting-proxy.test.ts
+++ b/test/strategies/unit/voting-proxy.test.ts
@@ -1,0 +1,88 @@
+import { scoreWithVotingProxy } from '../../../src/strategies/strategies/voting-proxy/proxyScoring';
+
+const direct = address('10');
+const source = address('20');
+const proxyHigh = address('30');
+const proxyLow = address('11');
+
+describe('voting-proxy scoring', () => {
+  it('returns source voting power for a zero-vp proxy voter', async () => {
+    const { result } = await scoreFixture({
+      addresses: [proxyHigh],
+      directScores: { [proxyHigh]: 0 },
+      sourceByProxy: { [proxyHigh]: source },
+      sourceScores: { [source]: 12 }
+    });
+
+    expect(result).toEqual({ [proxyHigh]: 12 });
+  });
+
+  it('keeps direct scores and only resolves zero-vp proxy candidates', async () => {
+    const { result, scoredAddressSets, resolvedAddressSets } =
+      await scoreFixture({
+        addresses: [direct, proxyHigh],
+        directScores: { [direct]: 7, [proxyHigh]: 0 },
+        sourceByProxy: { [proxyHigh]: source },
+        sourceScores: { [source]: 12 }
+      });
+
+    expect(result).toEqual({ [direct]: 7, [proxyHigh]: 12 });
+    expect(scoredAddressSets).toEqual([[direct, proxyHigh], [source]]);
+    expect(resolvedAddressSets).toEqual([[proxyHigh]]);
+  });
+
+  it('deduplicates voters resolving to the same source', async () => {
+    const { result, scoredAddressSets } = await scoreFixture({
+      addresses: [proxyHigh, proxyLow],
+      directScores: { [proxyHigh]: 0, [proxyLow]: 0 },
+      sourceByProxy: { [proxyHigh]: source, [proxyLow]: source },
+      sourceScores: { [source]: 12 }
+    });
+
+    expect(result).toEqual({ [proxyHigh]: 0, [proxyLow]: 12 });
+    expect(scoredAddressSets).toEqual([[proxyHigh, proxyLow], [source]]);
+  });
+
+  it('lets a direct source voter win over its proxy', async () => {
+    const { result } = await scoreFixture({
+      addresses: [source, proxyHigh],
+      directScores: { [source]: 12, [proxyHigh]: 0 },
+      sourceByProxy: { [proxyHigh]: source },
+      sourceScores: { [source]: 12 }
+    });
+
+    expect(result).toEqual({ [source]: 12, [proxyHigh]: 0 });
+  });
+});
+
+function address(byte: string): string {
+  return `0x${byte.repeat(20)}`;
+}
+
+async function scoreFixture({
+  addresses,
+  directScores = {},
+  sourceByProxy = {},
+  sourceScores = {}
+}) {
+  const scoredAddressSets: string[][] = [];
+  const resolvedAddressSets: string[][] = [];
+  let scoreCalls = 0;
+
+  const result = await scoreWithVotingProxy({
+    addresses,
+    scoreInner: async scoringAddresses => {
+      scoredAddressSets.push(scoringAddresses);
+      scoreCalls += 1;
+
+      return scoreCalls === 1 ? directScores : sourceScores;
+    },
+    resolveSources: async sourceCandidates => {
+      resolvedAddressSets.push(sourceCandidates);
+
+      return sourceByProxy;
+    }
+  });
+
+  return { result, scoredAddressSets, resolvedAddressSets };
+}

--- a/test/strategies/unit/voting-proxy.test.ts
+++ b/test/strategies/unit/voting-proxy.test.ts
@@ -12,15 +12,15 @@ const source = address('20');
 const proxyHigh = address('30');
 const proxyLow = address('11');
 const zeroAddress = address('00');
+const factory = address('40');
 const multicall3Address = '0xcA11bde05977b3631167028862bE2a173976CA11';
 const sourcePageSize = 200;
 const aggregate3Interface = new Interface([
   'function aggregate3(tuple(address target, bool allowFailure, bytes callData)[] calls) view returns (tuple(bool success, bytes returnData)[] returnData)'
 ]);
-const sourceInterface = new Interface([
-  'function source() view returns (address)'
+const factoryInterface = new Interface([
+  'function source(address proxy) view returns (address)'
 ]);
-const sourceCalldata = sourceInterface.encodeFunctionData('source', []);
 type ProviderCallTx = { to: string; data: string };
 type ProviderCall = [ProviderCallTx, number | 'latest'];
 type SourceResult = string | 'failed' | 'malformed';
@@ -93,7 +93,7 @@ describe('voting-proxy strategy', () => {
     getScoresDirectMock.mockReset();
   });
 
-  it('requires at least one configured proxy', async () => {
+  it('requires a configured factory', async () => {
     await expect(
       strategy(
         'space',
@@ -103,10 +103,10 @@ describe('voting-proxy strategy', () => {
         { strategies: [{ name: 'fixed-score' }] },
         123
       )
-    ).rejects.toThrow('voting-proxy requires at least one proxy');
+    ).rejects.toThrow('voting-proxy requires a factory');
   });
 
-  it('resolves zero-vp proxy sources with multicall3 allowFailure at the snapshot block', async () => {
+  it('resolves zero-vp proxy sources from a factory with multicall3 allowFailure at the snapshot block', async () => {
     const provider = createProvider([source]);
     getScoresDirectMock
       .mockResolvedValueOnce([{ [proxyHigh]: 0 }])
@@ -119,7 +119,7 @@ describe('voting-proxy strategy', () => {
     expect(firstProviderCall(provider)[0].to).toBe(multicall3Address);
     expect(firstProviderCall(provider)[1]).toBe(123);
     expect(decodeAggregate3Calls(provider)).toEqual([
-      [proxyHigh.toLowerCase(), true, sourceCalldata]
+      [factory, true, factorySourceCalldata(proxyHigh)]
     ]);
     expect(getScoresDirectMock).toHaveBeenNthCalledWith(
       2,
@@ -132,22 +132,21 @@ describe('voting-proxy strategy', () => {
     );
   });
 
-  it('ignores source lookups from voters outside the configured proxies', async () => {
-    const provider = createProvider([source]);
+  it('ignores voters not registered in the factory', async () => {
+    const provider = createProvider([zeroAddress, source]);
     getScoresDirectMock
       .mockResolvedValueOnce([{ [proxyHigh]: 0, [proxyLow]: 0 }])
       .mockResolvedValueOnce([{ [source]: 12 }]);
 
     await expect(
-      scoreStrategy(provider, [proxyHigh, proxyLow], 123, {
-        proxies: [proxyLow]
-      })
+      scoreStrategy(provider, [proxyHigh, proxyLow], 123)
     ).resolves.toEqual({
       [proxyHigh]: 0,
       [proxyLow]: 12
     });
     expect(decodeAggregate3Calls(provider)).toEqual([
-      [proxyLow.toLowerCase(), true, sourceCalldata]
+      [factory, true, factorySourceCalldata(proxyHigh)],
+      [factory, true, factorySourceCalldata(proxyLow)]
     ]);
   });
 
@@ -280,7 +279,11 @@ function encodeAggregate3Result(sourceResult: SourceResult): [boolean, string] {
 }
 
 function encodeSourceResult(sourceResult: string): string {
-  return sourceInterface.encodeFunctionResult('source', [sourceResult]);
+  return factoryInterface.encodeFunctionResult('source', [sourceResult]);
+}
+
+function factorySourceCalldata(proxy: string): string {
+  return factoryInterface.encodeFunctionData('source', [proxy.toLowerCase()]);
 }
 
 function firstProviderCall(
@@ -342,7 +345,7 @@ function scoreStrategy(
     '1',
     provider,
     addresses,
-    { proxies: addresses, strategies: [{ name: 'fixed-score' }], ...options },
+    { factory, strategies: [{ name: 'fixed-score' }], ...options },
     snapshot
   );
 }


### PR DESCRIPTION
## Summary

- Add the [`voting-proxy`](https://github.com/orbs-network/voting-proxy) Snapshot strategy to Score API.
- Resolve zero-VP proxy voters through a configured `VotingProxyFactory` with one multicall batch to `factory.source(voter)`.
- Score resolved source addresses with the configured inner strategies and return the source VP under the original proxy voter.
- Add manifest, schema, README, live example, and focused unit tests for source remapping, factory gating, and deduplication.

## Why

Older multisigs may be unable to upgrade to ERC-1271 or move voting power. A small voting proxy lets the multisig approve an exact Snapshot vote hash, while the factory records the source address that already holds voting power.

## Validation

- `npx --yes yarn@1.22.22 jest -i test/strategies/unit/voting-proxy.test.ts --config=jest.config.unit.ts`
- `npx --yes yarn@1.22.22 typecheck`
- `npx --yes yarn@1.22.22 test:strategy voting-proxy`
- `npx --yes yarn@1.22.22 test:strategy voting-proxy 500`
- `npx --yes yarn@1.22.22 lint`
- `npx --yes yarn@1.22.22 build`

## Reference

- Reference contract and local strategy tests: https://github.com/orbs-network/voting-proxy