### PR TITLE
fix: throttle upstream RPC-provider error reporting to stop log amplification

### DIFF
--- a/src/helpers/providerErrors.test.ts
+++ b/src/helpers/providerErrors.test.ts
@@ -1,0 +1,83 @@
+import {
+  _resetThrottle,
+  isProviderError,
+  shouldReport,
+  summarizeError
+} from './providerErrors';
+
+describe('providerErrors', () => {
+  beforeEach(() => {
+    _resetThrottle();
+  });
+
+  describe('isProviderError', () => {
+    it('detects ethers SERVER_ERROR', () => {
+      expect(isProviderError({ code: 'SERVER_ERROR' })).toBe(true);
+    });
+
+    it('detects TIMEOUT / NETWORK_ERROR / CALL_EXCEPTION', () => {
+      expect(isProviderError({ code: 'TIMEOUT' })).toBe(true);
+      expect(isProviderError({ code: 'NETWORK_ERROR' })).toBe(true);
+      expect(isProviderError({ code: 'CALL_EXCEPTION' })).toBe(true);
+    });
+
+    it('detects HTTP 403/5xx statuses', () => {
+      expect(isProviderError({ status: 403 })).toBe(true);
+      expect(isProviderError({ statusCode: 502 })).toBe(true);
+      expect(isProviderError({ error: { status: 503 } })).toBe(true);
+    });
+
+    it('detects the rpc.snapshot.org url signature', () => {
+      expect(
+        isProviderError({ error: { url: 'https://rpc.snapshot.org/1' } })
+      ).toBe(true);
+    });
+
+    it('returns false for input/validation errors', () => {
+      expect(isProviderError(new Error('invalid address'))).toBe(false);
+      expect(isProviderError({ code: 'INVALID_ARGUMENT' })).toBe(false);
+      expect(isProviderError(null)).toBe(false);
+      expect(isProviderError(undefined)).toBe(false);
+    });
+  });
+
+  describe('summarizeError', () => {
+    it('prefers the provider-issue shape', () => {
+      const e = {
+        reason: 'bad response',
+        error: { reason: '403', url: 'https://rpc.snapshot.org/1' }
+      };
+      expect(summarizeError(e)).toBe(
+        '[provider issue] https://rpc.snapshot.org/1, reason: bad response, 403'
+      );
+    });
+
+    it('includes code and message and is bounded to 256 chars', () => {
+      const e = { code: 'SERVER_ERROR', message: 'x'.repeat(1000) };
+      const out = summarizeError(e);
+      expect(out.startsWith('SERVER_ERROR: ')).toBe(true);
+      expect(out.length).toBeLessThanOrEqual(256);
+    });
+
+    it('handles missing error', () => {
+      expect(summarizeError(null)).toBe('Unknown error');
+    });
+  });
+
+  describe('shouldReport', () => {
+    it('reports the first occurrence then throttles within the window', () => {
+      const t0 = 1_000_000;
+      expect(shouldReport('k', t0)).toBe(true);
+      expect(shouldReport('k', t0 + 1)).toBe(false);
+      expect(shouldReport('k', t0 + 29_999)).toBe(false);
+      expect(shouldReport('k', t0 + 30_001)).toBe(true);
+    });
+
+    it('tracks keys independently', () => {
+      const t0 = 2_000_000;
+      expect(shouldReport('a', t0)).toBe(true);
+      expect(shouldReport('b', t0)).toBe(true);
+      expect(shouldReport('a', t0 + 1)).toBe(false);
+    });
+  });
+});

--- a/src/helpers/providerErrors.ts
+++ b/src/helpers/providerErrors.ts
@@ -1,0 +1,59 @@
+const PROVIDER_ERROR_CODES = new Set([
+  'SERVER_ERROR',
+  'TIMEOUT',
+  'NETWORK_ERROR',
+  'CALL_EXCEPTION'
+]);
+
+const PROVIDER_ERROR_STATUSES = new Set([403, 429, 500, 502, 503, 504]);
+
+export function isProviderError(e: any): boolean {
+  if (!e) return false;
+  if (typeof e.code === 'string' && PROVIDER_ERROR_CODES.has(e.code)) {
+    return true;
+  }
+  const status = e.status ?? e.statusCode ?? e.error?.status;
+  if (typeof status === 'number' && PROVIDER_ERROR_STATUSES.has(status)) {
+    return true;
+  }
+  // Proxy 403s can arrive with neither a code nor a status.
+  const url: string | undefined = e.error?.url ?? e.url ?? e.requestUrl;
+  if (typeof url === 'string' && url.includes('rpc.snapshot.org')) {
+    return true;
+  }
+  return false;
+}
+
+export function summarizeError(e: any): string {
+  if (!e) return 'Unknown error';
+  if (e?.reason && e?.error?.reason && e?.error?.url) {
+    return `[provider issue] ${e.error.url}, reason: ${e.reason}, ${e.error.reason}`;
+  }
+  const code = e.code ? `${e.code}: ` : '';
+  const message = e.message ?? String(e);
+  // An ethers message embeds the request body and the upstream response.
+  return `${code}${message}`.slice(0, 256);
+}
+
+const REPORT_WINDOW_MS = 30_000;
+const lastReportedAt = new Map<string, number>();
+const MAX_KEYS = 500;
+
+export function shouldReport(key: string, now: number = Date.now()): boolean {
+  const last = lastReportedAt.get(key);
+  if (last !== undefined && now - last < REPORT_WINDOW_MS) {
+    return false;
+  }
+  // The network segment of the key comes from the request body.
+  if (lastReportedAt.size >= MAX_KEYS && last === undefined) {
+    const oldestKey = lastReportedAt.keys().next().value;
+    if (oldestKey !== undefined) lastReportedAt.delete(oldestKey);
+  }
+  lastReportedAt.set(key, now);
+  return true;
+}
+
+// Only referenced from tests.
+export function _resetThrottle(): void {
+  lastReportedAt.clear();
+}

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -2,6 +2,11 @@ import { capture } from '@snapshot-labs/snapshot-sentry';
 import express from 'express';
 import { INVALID_ADDRESS_MESSAGE, MAX_STRATEGIES } from './constants';
 import disabled from './disabled.json';
+import {
+  isProviderError,
+  shouldReport,
+  summarizeError
+} from './helpers/providerErrors';
 import getStrategies from './helpers/strategies';
 import getValidations from './helpers/validations';
 import { getVp, validate, verifyGetVp, verifyValidate } from './methods';
@@ -51,6 +56,17 @@ function handlePostError(
   e: any,
   id: string | null
 ) {
+  if (isProviderError(e)) {
+    if (shouldReport(`provider:${method}:${e?.code ?? 'unknown'}`)) {
+      capture(e, { params, method });
+      console.log(
+        `[rpc] ${method} failed (upstream provider, throttled)`,
+        summarizeError(e)
+      );
+    }
+    return rpcError(res, 500, e, id);
+  }
+
   capture(e, { params, method });
   let error = JSON.stringify(e?.message || e || 'Unknown error').slice(0, 1000);
 
@@ -162,6 +178,20 @@ router.post('/api/scores', async (req, res) => {
       }
     );
   } catch (err: any) {
+    if (isProviderError(err)) {
+      if (shouldReport(`scores:${network}:${err?.code ?? 'unknown'}`)) {
+        capture(err, { params, strategies });
+        console.log(
+          '[rpc] Get scores failed (upstream provider, throttled)',
+          network,
+          space,
+          summarizeError(err),
+          requestId
+        );
+      }
+      return rpcError(res, 500, err, null);
+    }
+
     capture(err, { params, strategies });
     // @ts-ignore
     const errorMessage = err?.message || err || 'Unknown error';


### PR DESCRIPTION
## Problem

When the shared RPC proxy behind `rpc.snapshot.org` returns 403s or 5xx, every affected strategy call throws, and score-api writes a log line per failed request. That line stringifies the full strategies payload along with the error, so a brief upstream fault turns into sustained log volume that blocks the event loop. score-api then stops answering inside the HTTP header timeout and the uptime check opens an incident, which clears as soon as the burst does.

The upstream fault is short. The amplification is ours, and it is what turns the fault into an outage.

## Fix

New `src/helpers/providerErrors.ts`:

- `isProviderError` separates upstream RPC failures from genuine input and validation errors.
- `summarizeError` builds a bounded single-line summary, so the strategies payload and the full error object are no longer stringified per request.
- `shouldReport` allows one report per key per time window, keyed on method or network plus the error code.

`src/rpc.ts` applies these on both error paths. An upstream-provider error gets the bounded, throttled line. Everything else behaves exactly as before, and the 500 sent to the client is unchanged in all cases.

The Sentry capture is throttled on the same key, which makes the captures that survive a storm a predictable one per key per window rather than whichever ones happened to arrive first.

## Non-goals

The 403 itself is upstream and is being handled separately. Per-strategy provider timeouts are left alone, since tightening them would change scoring for slow but valid strategies and deserves its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
