### PR TITLE
feat: add grove-with-delegation strategy [grove-with-delegation]

### DIFF
--- a/src/strategies/strategies/grove-with-delegation/README.md
+++ b/src/strategies/strategies/grove-with-delegation/README.md
@@ -1,0 +1,19 @@
+# grove-with-delegation
+
+This strategy calculates voting power for Grove protocol governance with delegation support. Voting power is the actively staked GROVE balance — `activeBalanceOf` an account in the stGROVE vault (`0xF3Ddcaa3BD5D04ba08beC69cf34D9d9C9c112d14`). Stake that has been requested for withdrawal is excluded (using `activeBalanceOf` rather than `slashableBalanceOf` means an account cannot keep voting power while already queued to exit).
+
+## Parameters
+
+- `whitelistedDelegates` (optional): Array of addresses that should receive delegated balance. If not provided or empty, no addresses will receive delegated balance.
+- `symbol` (optional): Token symbol for display purposes (defaults to stGROVE)
+
+## How it works
+
+1. **For non-delegators**: They receive their own actively staked GROVE balance
+2. **For whitelisted delegates**: They receive their own balance + any delegated balance from others
+3. **For non-whitelisted delegates**: They only receive their own balance (delegations to them don't count)
+4. **For delegators**: They get 0 voting power as it's transferred to their delegates
+
+## Voting Power Calculation
+
+Total voting power = actively staked GROVE balance (stGROVE vault `activeBalanceOf`; withdrawal-queued stake excluded)

--- a/src/strategies/strategies/grove-with-delegation/examples.json
+++ b/src/strategies/strategies/grove-with-delegation/examples.json
@@ -1,0 +1,41 @@
+[
+  {
+    "name": "Example query with whitelisted delegates",
+    "strategy": {
+      "name": "grove-with-delegation",
+      "params": {
+        "symbol": "stGROVE",
+        "whitelistedDelegates": [
+          "0xE0B9B0d8F89a92142292408cE14FdAD195FD040f"
+        ]
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xE0B9B0d8F89a92142292408cE14FdAD195FD040f",
+      "0xF3Ddcaa3BD5D04ba08beC69cf34D9d9C9c112d14",
+      "0x1369f7b2b38c76B6478c0f0E66D94923421891Ba",
+      "0x491EDFB0B8b608044e227225C715981a30F3A44E",
+      "0x6D51cCd36B43a438f04f5433F3EFeddeF5E5dc4B"
+    ],
+    "snapshot": 25502973
+  },
+  {
+    "name": "Example query without whitelisted delegates",
+    "strategy": {
+      "name": "grove-with-delegation",
+      "params": {
+        "symbol": "stGROVE"
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xE0B9B0d8F89a92142292408cE14FdAD195FD040f",
+      "0xF3Ddcaa3BD5D04ba08beC69cf34D9d9C9c112d14",
+      "0x1369f7b2b38c76B6478c0f0E66D94923421891Ba",
+      "0x491EDFB0B8b608044e227225C715981a30F3A44E",
+      "0x6D51cCd36B43a438f04f5433F3EFeddeF5E5dc4B"
+    ],
+    "snapshot": 25502973
+  }
+]

--- a/src/strategies/strategies/grove-with-delegation/index.ts
+++ b/src/strategies/strategies/grove-with-delegation/index.ts
@@ -1,0 +1,104 @@
+import { getAddress } from '@ethersproject/address';
+import { getScoresDirect } from '../../utils';
+import { getDelegationsData } from '../../utils/delegation';
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  addresses = addresses.map(getAddress);
+
+  const groveStrategies = [
+    {
+      name: 'contract-call',
+      params: {
+        address: '0xF3Ddcaa3BD5D04ba08beC69cf34D9d9C9c112d14',
+        decimals: 18,
+        methodABI: {
+          name: 'activeBalanceOf',
+          type: 'function',
+          stateMutability: 'view',
+          inputs: [
+            {
+              name: 'account',
+              type: 'address'
+            }
+          ],
+          outputs: [
+            {
+              name: '',
+              type: 'uint256'
+            }
+          ]
+        }
+      }
+    }
+  ];
+
+  // Whitelisted delegates - only these addresses get delegated balance
+  const whitelistedDelegates = (options.whitelistedDelegates || []).map(
+    getAddress
+  );
+
+  const delegationsData = await getDelegationsData(
+    space,
+    '1',
+    addresses,
+    snapshot
+  );
+  const delegations = delegationsData.delegations;
+
+  // Get scores for all addresses and delegators
+  if (Object.keys(delegations).length === 0) return {};
+  const allAddresses = Object.values(delegations).reduce(
+    (a: string[], b: string[]) => a.concat(b),
+    []
+  );
+  allAddresses.push(...addresses);
+  const scores = (
+    await getScoresDirect(
+      space,
+      groveStrategies,
+      '1',
+      provider,
+      allAddresses,
+      snapshot
+    )
+  ).filter(score => Object.keys(score).length !== 0);
+
+  const finalScore = Object.fromEntries(
+    addresses.map(address => {
+      // Check if address is whitelisted delegate
+      const isWhitelistedDelegate = whitelistedDelegates.includes(address);
+
+      let addressScore = 0;
+
+      if (isWhitelistedDelegate && delegations[address]) {
+        // Whitelisted delegates get delegated balance
+        addressScore = delegations[address].reduce(
+          (a, b) => a + scores.reduce((x, y) => (y[b] ? x + y[b] : x), 0),
+          0
+        );
+      }
+
+      return [address, addressScore];
+    })
+  );
+
+  // Add own scores for all addresses (both whitelisted and non-whitelisted)
+  // but only if they haven't delegated to anyone
+  addresses.forEach(address => {
+    if (!delegationsData.allDelegators.includes(address)) {
+      finalScore[address] += scores.reduce(
+        (a, b) => a + (b[address] ? b[address] : 0),
+        0
+      );
+    }
+  });
+
+  return finalScore;
+}

--- a/src/strategies/strategies/grove-with-delegation/manifest.json
+++ b/src/strategies/strategies/grove-with-delegation/manifest.json
@@ -1,0 +1,5 @@
+{
+  "name": "Grove With Delegation",
+  "author": "snapshot-labs",
+  "version": "0.1.0"
+}


### PR DESCRIPTION
## Summary

Adds the `grove-with-delegation` strategy for Grove protocol governance. (From telegram group)

Voting power is the **actively staked GROVE balance** — `activeBalanceOf` of an account in the stGROVE vault (`0xF3Ddcaa3BD5D04ba08beC69cf34D9d9C9c112d14`). Using `activeBalanceOf` (rather than `slashableBalanceOf`) excludes stake that has already been requested for withdrawal, so an account queued to exit cannot keep voting power.

It reuses the same delegation model as the existing [`spark-with-delegation`](https://github.com/snapshot-labs/score-api/tree/master/src/strategies/strategies/spark-with-delegation) strategy:

- **Non-delegators** get their own actively staked balance.
- **Whitelisted delegates** (`whitelistedDelegates` param) get their own balance plus any delegated balance.
- **Non-whitelisted delegates** get only their own balance (delegations to them don't count).
- **Delegators** get 0 (power transfers to their delegate).

The only structural difference from `spark-with-delegation` is the token config: grove reads a single `contract-call` (`activeBalanceOf`) instead of `erc20-balance-of` + `slashableBalanceOf`.

## Parameters

- `whitelistedDelegates` (optional): addresses that should receive delegated balance. Empty/omitted → no address receives delegated balance.
- `symbol` (optional): display symbol (defaults to `stGROVE`).

## Note on CI

The strategy test currently fails the "at least 1 address with a positive score" check. This is a **data**, not code, issue: at the time of writing, the stGROVE vault has **zero total supply on mainnet** (verified at the example block and at chain head — `totalSupply()` and `activeBalanceOf`/`balanceOf` for all example addresses return 0). Once stGROVE has real stakers, `examples.json` needs to be updated with a block + addresses that carry a positive `activeBalanceOf`, and the suite will pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
