### PR TITLE
[lido-voting-delegation] feat: add Lido voting delegation strategy

### DIFF
--- a/src/strategies/strategies/lido-voting-delegation/README.md
+++ b/src/strategies/strategies/lido-voting-delegation/README.md
@@ -9,13 +9,24 @@ space should count each voter's own LDO balance as well.
 
 Snapshot delegations take precedence over Lido DAO `Voting` delegations. If a
 holder delegated in both systems, their voting power follows the Snapshot
-delegate. If a delegator is also present in the voter set, their delegated power
-is excluded from their delegate's score so the delegator can reclaim voting power
-by voting directly.
+delegate. Within the Snapshot Delegate Registry, a space-specific delegation
+overrides a global one, so a holder delegating globally to one address and
+space-specifically to another is counted only for the latter. If a delegator is
+also present in the voter set, their delegated power is excluded from their
+delegate's score so the delegator can reclaim voting power by voting directly.
 
 The strategy uses batched, address-scoped reads and supports snapshot block
 pinning. Zero address inputs are ignored for the Lido DAO `Voting` delegation
 reads because the `Voting` getters revert for `address(0)`.
+
+## Difference from the `delegation` strategy
+
+The space-specific override is resolved against all of a holder's delegations,
+not only those pointing at a scored address. `delegation` filters by delegate
+first, so a holder delegating globally to A and space-specifically to B is
+credited to A whenever B is not being scored — and since voting power is
+computed one address at a time, that is the usual case. Here such a holder is
+always credited to B.
 
 | Param Name        | Description                                                                      |
 | ----------------- | -------------------------------------------------------------------------------- |

--- a/src/strategies/strategies/lido-voting-delegation/README.md
+++ b/src/strategies/strategies/lido-voting-delegation/README.md
@@ -1,0 +1,38 @@
+# lido-voting-delegation
+
+This strategy returns delegated-in LDO voting power for Lido DAO delegates. It sums
+the LDO balances of accounts that delegated to each voter address through either
+the Snapshot Delegate Registry or Lido DAO `Voting` contract.
+
+It returns delegated power only. It must be used together with `erc20-balance-of` if the
+space should count each voter's own LDO balance as well.
+
+Snapshot delegations take precedence over Lido DAO `Voting` delegations. If a
+holder delegated in both systems, their voting power follows the Snapshot
+delegate. If a delegator is also present in the voter set, their delegated power
+is excluded from their delegate's score so the delegator can reclaim voting power
+by voting directly.
+
+The strategy uses batched, address-scoped reads and supports snapshot block
+pinning. Zero address inputs are ignored for the Lido DAO `Voting` delegation
+reads because the `Voting` getters revert for `address(0)`.
+
+| Param Name        | Description                                                                      |
+| ----------------- | -------------------------------------------------------------------------------- |
+| `address`         | ERC-20 token contract address used for balances. For Lido this is the LDO token. |
+| `decimals`        | Token decimals.                                                                  |
+| `votingContract`  | Lido DAO `Voting` contract proxy used for onchain delegation reads.              |
+| `symbol`          | Optional display symbol.                                                         |
+| `delegationSpace` | Optional Snapshot delegation space. Defaults to the proposal space.              |
+
+Here is an example of parameters:
+
+```json
+{
+  "symbol": "LDO",
+  "address": "0x5a98fcbea516cf06857215779fd812ca3bef1b32",
+  "decimals": 18,
+  "votingContract": "0x2e59A20f205bB85a89C53f1936454680651E618e",
+  "delegationSpace": "lido-snapshot.eth"
+}
+```

--- a/src/strategies/strategies/lido-voting-delegation/examples.json
+++ b/src/strategies/strategies/lido-voting-delegation/examples.json
@@ -1,0 +1,42 @@
+[
+  {
+    "name": "Snapshot + Lido Voting delegation union (real Lido delegates)",
+    "strategy": {
+      "name": "lido-voting-delegation",
+      "params": {
+        "symbol": "LDO",
+        "address": "0x5a98fcbea516cf06857215779fd812ca3bef1b32",
+        "decimals": 18,
+        "votingContract": "0x2e59A20f205bB85a89C53f1936454680651E618e",
+        "delegationSpace": "lido-snapshot.eth"
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x42E6DD8D517abB3E4f6611Ca53a8D1243C183fB0",
+      "0xB6647e02AE6Dd74137cB80b1C24333852E4AF890",
+      "0xa4181C75495f60106AE539B7C55c0D263f2fb737"
+    ],
+    "snapshot": 25073276
+  },
+  {
+    "name": "Override parity (a delegator that also voted is excluded)",
+    "strategy": {
+      "name": "lido-voting-delegation",
+      "params": {
+        "symbol": "LDO",
+        "address": "0x5a98fcbea516cf06857215779fd812ca3bef1b32",
+        "decimals": 18,
+        "votingContract": "0x2e59A20f205bB85a89C53f1936454680651E618e",
+        "delegationSpace": "lido-snapshot.eth"
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x42E6DD8D517abB3E4f6611Ca53a8D1243C183fB0",
+      "0x3d56d86a60b92132b37f226EA5A23F84C805Ce29",
+      "0xa4181C75495f60106AE539B7C55c0D263f2fb737"
+    ],
+    "snapshot": 25073276
+  }
+]

--- a/src/strategies/strategies/lido-voting-delegation/index.test.ts
+++ b/src/strategies/strategies/lido-voting-delegation/index.test.ts
@@ -1,0 +1,248 @@
+import { getAddress } from '@ethersproject/address';
+
+const mockSubgraphRequest = jest.fn();
+const mockGetVotingDelegators = jest.fn();
+const mockErc20BalanceOf = jest.fn();
+
+jest.mock('../../utils', () => ({
+  subgraphRequest: (...args: any[]) => mockSubgraphRequest(...args),
+  SNAPSHOT_SUBGRAPH_URL: { '1': 'https://mock.com' }
+}));
+
+jest.mock('./votingDelegations', () => ({
+  getVotingDelegators: (...args: any[]) => mockGetVotingDelegators(...args)
+}));
+
+jest.mock('../erc20-balance-of', () => ({
+  strategy: (...args: any[]) => mockErc20BalanceOf(...args)
+}));
+
+import { strategy } from './index';
+
+const SPACE = 'lido-snapshot.eth';
+const NETWORK = '1';
+const GLOBAL = '';
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+const LDO_TOKEN = getAddress('0x' + 'ff'.repeat(20));
+const VOTING_CONTRACT = getAddress('0x' + 'ee'.repeat(20));
+
+// Scored delegates
+const DELEGATE_A = getAddress('0x' + 'a1'.repeat(20));
+const DELEGATE_B = getAddress('0x' + 'b2'.repeat(20));
+// Delegate outside the scored set
+const UNSCORED_DELEGATE = getAddress('0x' + 'c3'.repeat(20));
+// Delegators
+const SNAPSHOT_DELEGATOR = getAddress('0x' + 'd4'.repeat(20));
+const VOTING_DELEGATOR = getAddress('0x' + 'e5'.repeat(20));
+
+interface DelegationRow {
+  delegator: string;
+  delegate: string;
+  space: string;
+  timestamp: number;
+}
+
+function row(
+  delegator: string,
+  delegate: string,
+  space: string,
+  timestamp: number
+): DelegationRow {
+  return {
+    delegator: delegator.toLowerCase(),
+    delegate: delegate.toLowerCase(),
+    space,
+    timestamp
+  };
+}
+
+describe('lido-voting-delegation strategy', () => {
+  // In-memory Delegate Registry: rows served through the same `where` filters the strategy sends
+  let subgraphRows: DelegationRow[];
+  // Address → balance map
+  let balances: Record<string, number>;
+
+  beforeEach(() => {
+    subgraphRows = [];
+    balances = {};
+
+    mockSubgraphRequest.mockImplementation(async (_url, params) => {
+      const { where, first } = params.delegations.__args;
+      const delegations = subgraphRows
+        .filter(r => where.space_in.includes(r.space))
+        .filter(
+          r => !where.delegate_in || where.delegate_in.includes(r.delegate)
+        )
+        .filter(
+          r => !where.delegator_in || where.delegator_in.includes(r.delegator)
+        )
+        .filter(r => r.timestamp >= where.timestamp_gte)
+        .sort((a, b) => a.timestamp - b.timestamp)
+        .slice(0, first);
+      return { delegations };
+    });
+
+    mockGetVotingDelegators.mockResolvedValue({});
+
+    mockErc20BalanceOf.mockImplementation(
+      async (_space, _network, _provider, addresses: string[]) =>
+        Object.fromEntries(
+          addresses.map(address => [address, balances[address] ?? 0])
+        )
+    );
+  });
+
+  function run(
+    addresses: string[] = [DELEGATE_A, DELEGATE_B],
+    extraOptions: Record<string, any> = {}
+  ) {
+    return strategy(
+      SPACE,
+      NETWORK,
+      {},
+      addresses,
+      {
+        address: LDO_TOKEN,
+        votingContract: VOTING_CONTRACT,
+        ...extraOptions
+      },
+      'latest'
+    );
+  }
+
+  it('credits a global Snapshot delegation to its scored delegate', async () => {
+    subgraphRows = [row(SNAPSHOT_DELEGATOR, DELEGATE_A, GLOBAL, 1)];
+    balances[SNAPSHOT_DELEGATOR] = 100;
+
+    expect(await run()).toEqual({ [DELEGATE_A]: 100, [DELEGATE_B]: 0 });
+  });
+
+  it('does not credit a global delegation overridden by a space-scoped one pointing outside the scored set', async () => {
+    // The space-scoped row wins even though the global one is newer, so the
+    // delegator's power belongs to the unscored delegate and must not inflate
+    // DELEGATE_A
+    subgraphRows = [
+      row(SNAPSHOT_DELEGATOR, UNSCORED_DELEGATE, SPACE, 1),
+      row(SNAPSHOT_DELEGATOR, DELEGATE_A, GLOBAL, 2)
+    ];
+    balances[SNAPSHOT_DELEGATOR] = 100;
+
+    expect(await run()).toEqual({ [DELEGATE_A]: 0, [DELEGATE_B]: 0 });
+  });
+
+  it('credits a space-scoped delegation to a scored delegate over a global one pointing outside the scored set', async () => {
+    subgraphRows = [
+      row(SNAPSHOT_DELEGATOR, DELEGATE_A, SPACE, 1),
+      row(SNAPSHOT_DELEGATOR, UNSCORED_DELEGATE, GLOBAL, 2)
+    ];
+    balances[SNAPSHOT_DELEGATOR] = 100;
+
+    expect(await run()).toEqual({ [DELEGATE_A]: 100, [DELEGATE_B]: 0 });
+  });
+
+  it('credits only the space-scoped delegate when global and space-scoped delegates are both scored', async () => {
+    subgraphRows = [
+      row(SNAPSHOT_DELEGATOR, DELEGATE_B, SPACE, 1),
+      row(SNAPSHOT_DELEGATOR, DELEGATE_A, GLOBAL, 2)
+    ];
+    balances[SNAPSHOT_DELEGATOR] = 100;
+
+    expect(await run()).toEqual({ [DELEGATE_A]: 0, [DELEGATE_B]: 100 });
+  });
+
+  it('treats a delegation to the `.eth`-less space alias as space-scoped', async () => {
+    subgraphRows = [
+      row(SNAPSHOT_DELEGATOR, DELEGATE_B, SPACE.replace('.eth', ''), 1),
+      row(SNAPSHOT_DELEGATOR, DELEGATE_A, GLOBAL, 2)
+    ];
+    balances[SNAPSHOT_DELEGATOR] = 100;
+
+    expect(await run()).toEqual({ [DELEGATE_A]: 0, [DELEGATE_B]: 100 });
+  });
+
+  it('credits a Voting delegator that has no Snapshot delegation', async () => {
+    mockGetVotingDelegators.mockResolvedValue({
+      [DELEGATE_A]: [VOTING_DELEGATOR]
+    });
+    balances[VOTING_DELEGATOR] = 40;
+
+    expect(await run()).toEqual({ [DELEGATE_A]: 40, [DELEGATE_B]: 0 });
+  });
+
+  it('does not credit a Voting delegator that has any Snapshot delegation (Snapshot wins)', async () => {
+    mockGetVotingDelegators.mockResolvedValue({
+      [DELEGATE_A]: [VOTING_DELEGATOR]
+    });
+    subgraphRows = [row(VOTING_DELEGATOR, UNSCORED_DELEGATE, GLOBAL, 1)];
+    balances[VOTING_DELEGATOR] = 40;
+
+    expect(await run()).toEqual({ [DELEGATE_A]: 0, [DELEGATE_B]: 0 });
+  });
+
+  it('does not credit a delegator that is itself in the scored set (votes directly)', async () => {
+    subgraphRows = [row(DELEGATE_B, DELEGATE_A, GLOBAL, 1)];
+    mockGetVotingDelegators.mockResolvedValue({ [DELEGATE_A]: [DELEGATE_B] });
+    balances[DELEGATE_B] = 50;
+
+    expect(await run()).toEqual({ [DELEGATE_A]: 0, [DELEGATE_B]: 0 });
+  });
+
+  it('sums the balances of all credited delegators per delegate', async () => {
+    subgraphRows = [row(SNAPSHOT_DELEGATOR, DELEGATE_A, GLOBAL, 1)];
+    mockGetVotingDelegators.mockResolvedValue({
+      [DELEGATE_A]: [VOTING_DELEGATOR]
+    });
+    balances[SNAPSHOT_DELEGATOR] = 100;
+    balances[VOTING_DELEGATOR] = 40;
+
+    expect(await run()).toEqual({ [DELEGATE_A]: 140, [DELEGATE_B]: 0 });
+  });
+
+  it('credits the Snapshot delegate when a delegator delegates to different scored delegates in both systems', async () => {
+    subgraphRows = [row(SNAPSHOT_DELEGATOR, DELEGATE_B, GLOBAL, 1)];
+    mockGetVotingDelegators.mockResolvedValue({
+      [DELEGATE_A]: [SNAPSHOT_DELEGATOR]
+    });
+    balances[SNAPSHOT_DELEGATOR] = 100;
+
+    expect(await run()).toEqual({ [DELEGATE_A]: 0, [DELEGATE_B]: 100 });
+  });
+
+  it('counts a delegator once when it delegates to the same delegate in both systems', async () => {
+    subgraphRows = [row(SNAPSHOT_DELEGATOR, DELEGATE_A, GLOBAL, 1)];
+    mockGetVotingDelegators.mockResolvedValue({
+      [DELEGATE_A]: [SNAPSHOT_DELEGATOR]
+    });
+    balances[SNAPSHOT_DELEGATOR] = 100;
+
+    expect(await run()).toEqual({ [DELEGATE_A]: 100, [DELEGATE_B]: 0 });
+  });
+
+  it('resolves Snapshot delegations against the delegationSpace option instead of the space', async () => {
+    const delegationSpace = 'lido.eth';
+    subgraphRows = [row(SNAPSHOT_DELEGATOR, DELEGATE_A, delegationSpace, 1)];
+    balances[SNAPSHOT_DELEGATOR] = 100;
+
+    expect(await run([DELEGATE_A, DELEGATE_B], { delegationSpace })).toEqual({
+      [DELEGATE_A]: 100,
+      [DELEGATE_B]: 0
+    });
+  });
+
+  it('excludes the zero address from Voting contract reads', async () => {
+    subgraphRows = [row(SNAPSHOT_DELEGATOR, DELEGATE_A, GLOBAL, 1)];
+    balances[SNAPSHOT_DELEGATOR] = 100;
+
+    expect(await run([DELEGATE_A, DELEGATE_B, ZERO_ADDRESS])).toEqual({
+      [DELEGATE_A]: 100,
+      [DELEGATE_B]: 0,
+      [ZERO_ADDRESS]: 0
+    });
+    // getVotingDelegators(network, provider, votingContract, addresses, blockTag)
+    expect(mockGetVotingDelegators.mock.calls[0][3]).toEqual([
+      DELEGATE_A,
+      DELEGATE_B
+    ]);
+  });
+});

--- a/src/strategies/strategies/lido-voting-delegation/index.test.ts
+++ b/src/strategies/strategies/lido-voting-delegation/index.test.ts
@@ -1,22 +1,17 @@
 import { getAddress } from '@ethersproject/address';
-
 const mockSubgraphRequest = jest.fn();
 const mockGetVotingDelegators = jest.fn();
 const mockErc20BalanceOf = jest.fn();
-
 jest.mock('../../utils', () => ({
   subgraphRequest: (...args: any[]) => mockSubgraphRequest(...args),
   SNAPSHOT_SUBGRAPH_URL: { '1': 'https://mock.com' }
 }));
-
 jest.mock('./votingDelegations', () => ({
   getVotingDelegators: (...args: any[]) => mockGetVotingDelegators(...args)
 }));
-
 jest.mock('../erc20-balance-of', () => ({
   strategy: (...args: any[]) => mockErc20BalanceOf(...args)
 }));
-
 import { strategy } from './index';
 
 const SPACE = 'lido-snapshot.eth';
@@ -24,17 +19,17 @@ const NETWORK = '1';
 const GLOBAL = '';
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
-const LDO_TOKEN = getAddress('0x' + 'ff'.repeat(20));
-const VOTING_CONTRACT = getAddress('0x' + 'ee'.repeat(20));
+const LDO_TOKEN = getAddress(`0x${'ff'.repeat(20)}`);
+const VOTING_CONTRACT = getAddress(`0x${'ee'.repeat(20)}`);
 
 // Scored delegates
-const DELEGATE_A = getAddress('0x' + 'a1'.repeat(20));
-const DELEGATE_B = getAddress('0x' + 'b2'.repeat(20));
+const DELEGATE_A = getAddress(`0x${'a1'.repeat(20)}`);
+const DELEGATE_B = getAddress(`0x${'b2'.repeat(20)}`);
 // Delegate outside the scored set
-const UNSCORED_DELEGATE = getAddress('0x' + 'c3'.repeat(20));
+const UNSCORED_DELEGATE = getAddress(`0x${'c3'.repeat(20)}`);
 // Delegators
-const SNAPSHOT_DELEGATOR = getAddress('0x' + 'd4'.repeat(20));
-const VOTING_DELEGATOR = getAddress('0x' + 'e5'.repeat(20));
+const SNAPSHOT_DELEGATOR = getAddress(`0x${'d4'.repeat(20)}`);
+const VOTING_DELEGATOR = getAddress(`0x${'e5'.repeat(20)}`);
 
 interface DelegationRow {
   delegator: string;

--- a/src/strategies/strategies/lido-voting-delegation/index.ts
+++ b/src/strategies/strategies/lido-voting-delegation/index.ts
@@ -1,10 +1,10 @@
 import { getAddress } from '@ethersproject/address';
 import { strategy as erc20BalanceOfStrategy } from '../erc20-balance-of';
-import { getVotingDelegators } from './votingDelegations';
 import {
   getSnapshotDelegationCandidates,
   getSnapshotEffectiveDelegates
 } from './snapshotDelegations';
+import { getVotingDelegators } from './votingDelegations';
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 

--- a/src/strategies/strategies/lido-voting-delegation/index.ts
+++ b/src/strategies/strategies/lido-voting-delegation/index.ts
@@ -2,8 +2,8 @@ import { getAddress } from '@ethersproject/address';
 import { strategy as erc20BalanceOfStrategy } from '../erc20-balance-of';
 import { getVotingDelegators } from './votingDelegations';
 import {
-  getSnapshotDelegations,
-  getSnapshotDelegatorSet
+  getSnapshotDelegationCandidates,
+  getSnapshotEffectiveDelegates
 } from './snapshotDelegations';
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
@@ -19,7 +19,9 @@ export async function strategy(
   const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
   const votingContract = options.votingContract;
   const delegationSpace = options.delegationSpace || space;
-  const addressesLc = new Set(addresses.map((a: string) => a.toLowerCase()));
+  const scoredAddressByLc = new Map<string, string>(
+    addresses.map((address: string) => [address.toLowerCase(), address])
+  );
   const votingAddresses = addresses.filter(
     (address: string) => address.toLowerCase() !== ZERO_ADDRESS
   );
@@ -28,8 +30,8 @@ export async function strategy(
   const delegations: Record<string, Set<string>> = {};
   addresses.forEach((address: string) => (delegations[address] = new Set()));
 
-  // Fetch both Voting and Snapshot delegators
-  const [votingDelegatorsMap, snapshotDelegatorsMap] = await Promise.all([
+  // Fetch Voting delegators and the Snapshot delegators pointing at a scored delegate
+  const [votingDelegatorsMap, snapshotCandidates] = await Promise.all([
     getVotingDelegators(
       network,
       provider,
@@ -37,46 +39,60 @@ export async function strategy(
       votingAddresses,
       blockTag
     ),
-    getSnapshotDelegations(delegationSpace, network, addresses, snapshot)
+    getSnapshotDelegationCandidates(
+      delegationSpace,
+      network,
+      addresses,
+      snapshot
+    )
   ]);
 
-  // Snapshot delegators go in first; the Voting pass below defers to them (Snapshot wins).
-  Object.entries(snapshotDelegatorsMap).forEach(([delegate, delegators]) => {
-    delegators.forEach(delegator =>
-      delegations[delegate].add(getAddress(delegator))
-    );
-  });
-
-  // A delegator from Voting is credited only if it has no Snapshot delegation.
   const votingCandidates: { delegate: string; delegator: string }[] = [];
   Object.entries(votingDelegatorsMap).forEach(([delegate, delegators]) => {
     delegators.forEach((delegator: string) => {
-      if (addressesLc.has(delegator.toLowerCase())) {
+      if (scoredAddressByLc.has(delegator.toLowerCase())) {
         return; // delegator is voting directly → keeps its own power
       }
       votingCandidates.push({ delegate, delegator });
     });
   });
 
-  // Apply the "Snapshot wins" rule: if a delegator has a Snapshot delegation, it is not credited to its Voting delegate.
-  if (votingCandidates.length > 0) {
-    const uniqueDelegators = [
-      ...new Set(votingCandidates.map(c => c.delegator))
-    ];
-    const snapshotDelegators = await getSnapshotDelegatorSet(
-      delegationSpace,
-      network,
-      uniqueDelegators,
-      snapshot
-    );
-    votingCandidates.forEach(({ delegate, delegator }) => {
-      if (snapshotDelegators.has(delegator.toLowerCase())) {
-        return; // Snapshot wins
-      }
+  // One `delegator_in` read serves both sides: the Snapshot delegator's effective
+  // delegate, and whether a Voting delegator has a Snapshot delegation at all.
+  const effectiveSnapshotDelegates = await getSnapshotEffectiveDelegates(
+    delegationSpace,
+    network,
+    [
+      ...snapshotCandidates,
+      ...votingCandidates.map(candidate => candidate.delegator)
+    ],
+    snapshot
+  );
 
-      delegations[delegate].add(getAddress(delegator));
-    });
-  }
+  snapshotCandidates.forEach(delegator => {
+    const effectiveDelegate = effectiveSnapshotDelegates.get(delegator);
+    if (!effectiveDelegate) {
+      return;
+    }
+
+    // A space-specific override can point outside the scored set; that power
+    // belongs to the override target, not to any scored delegate.
+    const scoredDelegate = scoredAddressByLc.get(effectiveDelegate);
+    if (!scoredDelegate) {
+      return;
+    }
+
+    delegations[scoredDelegate].add(getAddress(delegator));
+  });
+
+  // A delegator from Voting is credited only if it has no Snapshot delegation.
+  votingCandidates.forEach(({ delegate, delegator }) => {
+    if (effectiveSnapshotDelegates.has(delegator.toLowerCase())) {
+      return; // Snapshot wins
+    }
+
+    delegations[delegate].add(getAddress(delegator));
+  });
 
   // Unique delegators across all delegates
   const allDelegators = [

--- a/src/strategies/strategies/lido-voting-delegation/index.ts
+++ b/src/strategies/strategies/lido-voting-delegation/index.ts
@@ -1,0 +1,109 @@
+import { getAddress } from '@ethersproject/address';
+import { strategy as erc20BalanceOfStrategy } from '../erc20-balance-of';
+import { getVotingDelegators } from './votingDelegations';
+import {
+  getSnapshotDelegations,
+  getSnapshotDelegatorSet
+} from './snapshotDelegations';
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+  const votingContract = options.votingContract;
+  const delegationSpace = options.delegationSpace || space;
+  const addressesLc = new Set(addresses.map((a: string) => a.toLowerCase()));
+  const votingAddresses = addresses.filter(
+    (address: string) => address.toLowerCase() !== ZERO_ADDRESS
+  );
+
+  // delegate → set of its delegators, accumulated from both sources
+  const delegations: Record<string, Set<string>> = {};
+  addresses.forEach((address: string) => (delegations[address] = new Set()));
+
+  // Fetch both Voting and Snapshot delegators
+  const [votingDelegatorsMap, snapshotDelegatorsMap] = await Promise.all([
+    getVotingDelegators(
+      network,
+      provider,
+      votingContract,
+      votingAddresses,
+      blockTag
+    ),
+    getSnapshotDelegations(delegationSpace, network, addresses, snapshot)
+  ]);
+
+  // Snapshot delegators go in first; the Voting pass below defers to them (Snapshot wins).
+  Object.entries(snapshotDelegatorsMap).forEach(([delegate, delegators]) => {
+    delegators.forEach(delegator =>
+      delegations[delegate].add(getAddress(delegator))
+    );
+  });
+
+  // A delegator from Voting is credited only if it has no Snapshot delegation.
+  const votingCandidates: { delegate: string; delegator: string }[] = [];
+  Object.entries(votingDelegatorsMap).forEach(([delegate, delegators]) => {
+    delegators.forEach((delegator: string) => {
+      if (addressesLc.has(delegator.toLowerCase())) {
+        return; // delegator is voting directly → keeps its own power
+      }
+      votingCandidates.push({ delegate, delegator });
+    });
+  });
+
+  // Apply the "Snapshot wins" rule: if a delegator has a Snapshot delegation, it is not credited to its Voting delegate.
+  if (votingCandidates.length > 0) {
+    const uniqueDelegators = [
+      ...new Set(votingCandidates.map(c => c.delegator))
+    ];
+    const snapshotDelegators = await getSnapshotDelegatorSet(
+      delegationSpace,
+      network,
+      uniqueDelegators,
+      snapshot
+    );
+    votingCandidates.forEach(({ delegate, delegator }) => {
+      if (snapshotDelegators.has(delegator.toLowerCase())) {
+        return; // Snapshot wins
+      }
+
+      delegations[delegate].add(getAddress(delegator));
+    });
+  }
+
+  // Unique delegators across all delegates
+  const allDelegators = [
+    ...new Set(Object.values(delegations).flatMap(set => [...set]))
+  ];
+  if (allDelegators.length === 0) {
+    return Object.fromEntries(addresses.map((address: string) => [address, 0]));
+  }
+
+  // Fetch all delegators LDO balances
+  const score = await erc20BalanceOfStrategy(
+    space,
+    network,
+    provider,
+    allDelegators,
+    options,
+    snapshot
+  );
+
+  // Each delegate's score is the sum of its delegators' LDO balances
+  return Object.fromEntries(
+    addresses.map((address: string) => [
+      address,
+      [...delegations[address]].reduce(
+        (total, delegator) => total + (score[delegator] || 0),
+        0
+      )
+    ])
+  );
+}

--- a/src/strategies/strategies/lido-voting-delegation/manifest.json
+++ b/src/strategies/strategies/lido-voting-delegation/manifest.json
@@ -1,0 +1,6 @@
+{
+  "name": "Lido Voting Delegation",
+  "author": "katamarinaki",
+  "version": "0.1.0",
+  "overriding": true
+}

--- a/src/strategies/strategies/lido-voting-delegation/schema.json
+++ b/src/strategies/strategies/lido-voting-delegation/schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "type": "string",
+          "title": "Symbol",
+          "examples": ["e.g. LDO"],
+          "maxLength": 16
+        },
+        "address": {
+          "type": "string",
+          "title": "Token contract address",
+          "examples": ["e.g. 0x5a98fcbea516cf06857215779fd812ca3bef1b32"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "decimals": {
+          "type": "number",
+          "title": "Decimals",
+          "examples": ["e.g. 18"],
+          "minimum": 0
+        },
+        "votingContract": {
+          "type": "string",
+          "title": "Lido Voting contract address",
+          "examples": ["e.g. 0x2e59A20f205bB85a89C53f1936454680651E618e"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "delegationSpace": {
+          "type": "string",
+          "title": "Snapshot-registry delegation space",
+          "examples": ["e.g. lido-snapshot.eth"],
+          "maxLength": 64
+        }
+      },
+      "required": ["address", "decimals", "votingContract"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/strategies/strategies/lido-voting-delegation/snapshotDelegations.ts
+++ b/src/strategies/strategies/lido-voting-delegation/snapshotDelegations.ts
@@ -1,0 +1,180 @@
+import { getAddress } from '@ethersproject/address';
+import { subgraphRequest, SNAPSHOT_SUBGRAPH_URL } from '../../utils';
+
+// "snapshot.js" below refers to the @snapshot-labs/snapshot.js SDK, whose
+// delegation helpers (buildSpaceIn, getDelegatesBySpace) this file mirrors so
+// its output matches the canonical utils/delegation.getDelegations.
+
+const PAGE_SIZE = 1000;
+const CHUNK_SIZE = 500; // max addresses per `_in` filter
+
+// Snapshot delegations are scoped to the space, its `.eth`-less alias, or
+// global (''). Mirrors snapshot.js `buildSpaceIn`.
+function buildSpaceIn(space: string): string[] {
+  const spaces = ['', space];
+  if (space.includes('.eth')) {
+    spaces.push(space.replace('.eth', ''));
+  }
+  return spaces;
+}
+
+function chunk<T>(arr: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) {
+    out.push(arr.slice(i, i + size));
+  }
+
+  return out;
+}
+
+// Paginate the `delegations` query matching `where` (timestamp pivot + dedup),
+// like snapshot.js `getDelegatesBySpace`.
+async function queryDelegations(
+  subgraphUrl: string,
+  where: Record<string, any>,
+  snapshot: number | 'latest'
+): Promise<any[]> {
+  const byKey = new Map<string, any>();
+  let pivot = 0;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const params: any = {
+      delegations: {
+        __args: {
+          where: { ...where, timestamp_gte: pivot },
+          first: PAGE_SIZE,
+          skip: 0,
+          orderBy: 'timestamp',
+          orderDirection: 'asc'
+        },
+        delegator: true,
+        space: true,
+        delegate: true,
+        timestamp: true
+      }
+    };
+    if (snapshot !== 'latest') {
+      params.delegations.__args.block = { number: snapshot };
+    }
+
+    const page: any[] =
+      (await subgraphRequest(subgraphUrl, params))?.delegations || [];
+
+    // Same guard as snapshot.js: a full page whose first and last rows share a
+    // timestamp can't be paged past, so bail instead of looping forever.
+    if (
+      page.length === PAGE_SIZE &&
+      page[0].timestamp === page[page.length - 1].timestamp
+    ) {
+      throw new Error('Unable to paginate Snapshot delegations');
+    }
+
+    page.forEach(delegation => {
+      byKey.set(
+        `${delegation.delegator}-${delegation.delegate}-${delegation.space}`,
+        delegation
+      );
+      pivot = delegation.timestamp;
+    });
+    if (page.length < PAGE_SIZE) {
+      break;
+    }
+  }
+  return [...byKey.values()];
+}
+
+/**
+ * Each queried delegate's Snapshot delegators (delegate → delegators), read from
+ * the Delegate Registry v1. Scoped via `delegate_in` to avoid paginating the
+ * whole space; output matches `utils/delegation.getDelegations`.
+ */
+export async function getSnapshotDelegations(
+  space: string,
+  network: string,
+  addresses: string[],
+  snapshot: number | 'latest'
+): Promise<Record<string, string[]>> {
+  const subgraphUrl = SNAPSHOT_SUBGRAPH_URL[network];
+  if (!subgraphUrl) {
+    return {};
+  }
+
+  const addressesLc = addresses.map(address => address.toLowerCase());
+  const spaceIn = buildSpaceIn(space);
+
+  const rows = (
+    await Promise.all(
+      chunk(addressesLc, CHUNK_SIZE).map(part =>
+        queryDelegations(
+          subgraphUrl,
+          { space_in: spaceIn, delegate_in: part },
+          snapshot
+        )
+      )
+    )
+  ).flat();
+
+  // Override + space precedence, identical to `utils/delegation.getDelegations`:
+  // drop delegators that are themselves voting, and let a space-specific
+  // delegation override a global ('') one.
+  const delegations = rows.filter(
+    delegation =>
+      addressesLc.includes(delegation.delegate) &&
+      !addressesLc.includes(delegation.delegator)
+  );
+  const delegationsReverse: Record<string, string> = {};
+  delegations.forEach(
+    delegation =>
+      (delegationsReverse[delegation.delegator] = delegation.delegate)
+  );
+  delegations
+    .filter(delegation => delegation.space !== '')
+    .forEach(
+      delegation =>
+        (delegationsReverse[delegation.delegator] = delegation.delegate)
+    );
+
+  return Object.fromEntries(
+    addresses.map(address => [
+      address,
+      Object.entries(delegationsReverse)
+        .filter(([, delegate]) => address.toLowerCase() === delegate)
+        .map(([delegator]) => getAddress(delegator))
+    ])
+  );
+}
+
+/**
+ * The subset of `delegators` (lowercased) that have **any** Snapshot
+ * delegation in the space — used to enforce "Snapshot wins": a Voting delegator
+ * is only credited onchain if it has no Snapshot delegation. Address-scoped via
+ * `delegator_in`, so it reads only these delegators' rows, not the whole space.
+ */
+export async function getSnapshotDelegatorSet(
+  space: string,
+  network: string,
+  delegators: string[],
+  snapshot: number | 'latest'
+): Promise<Set<string>> {
+  const subgraphUrl = SNAPSHOT_SUBGRAPH_URL[network];
+  if (!subgraphUrl || delegators.length === 0) {
+    return new Set();
+  }
+
+  const delegatorsLc = delegators.map(delegator => delegator.toLowerCase());
+  const spaceIn = buildSpaceIn(space);
+
+  const rows = (
+    await Promise.all(
+      chunk(delegatorsLc, CHUNK_SIZE).map(part =>
+        queryDelegations(
+          subgraphUrl,
+          { space_in: spaceIn, delegator_in: part },
+          snapshot
+        )
+      )
+    )
+  ).flat();
+
+  return new Set(rows.map(delegation => delegation.delegator));
+}

--- a/src/strategies/strategies/lido-voting-delegation/snapshotDelegations.ts
+++ b/src/strategies/strategies/lido-voting-delegation/snapshotDelegations.ts
@@ -1,4 +1,4 @@
-import { subgraphRequest, SNAPSHOT_SUBGRAPH_URL } from '../../utils';
+import { SNAPSHOT_SUBGRAPH_URL, subgraphRequest } from '../../utils';
 
 // Mirrors the snapshot.js delegation helpers (buildSpaceIn, getDelegatesBySpace),
 // but resolves precedence like `utils/delegation.getDelegationsData` rather than
@@ -38,7 +38,6 @@ async function queryDelegations(
 ): Promise<any[]> {
   const byKey = new Map<string, any>();
   let pivot = 0;
-  // eslint-disable-next-line no-constant-condition
   while (true) {
     const params: any = {
       delegations: {

--- a/src/strategies/strategies/lido-voting-delegation/snapshotDelegations.ts
+++ b/src/strategies/strategies/lido-voting-delegation/snapshotDelegations.ts
@@ -1,9 +1,11 @@
-import { getAddress } from '@ethersproject/address';
 import { subgraphRequest, SNAPSHOT_SUBGRAPH_URL } from '../../utils';
 
-// "snapshot.js" below refers to the @snapshot-labs/snapshot.js SDK, whose
-// delegation helpers (buildSpaceIn, getDelegatesBySpace) this file mirrors so
-// its output matches the canonical utils/delegation.getDelegations.
+// Mirrors the snapshot.js delegation helpers (buildSpaceIn, getDelegatesBySpace),
+// but resolves precedence like `utils/delegation.getDelegationsData` rather than
+// `getDelegations`: the latter drops rows whose delegate is not being scored
+// before applying the override, so a space-specific delegation pointing outside
+// the scored set cannot win. Scores here can differ from the `delegation`
+// strategy for that reason.
 
 const PAGE_SIZE = 1000;
 const CHUNK_SIZE = 500; // max addresses per `_in` filter
@@ -84,27 +86,28 @@ async function queryDelegations(
 }
 
 /**
- * Each queried delegate's Snapshot delegators (delegate → delegators), read from
- * the Delegate Registry v1. Scoped via `delegate_in` to avoid paginating the
- * whole space; output matches `utils/delegation.getDelegations`.
+ * Delegators (lowercased) with at least one delegation row pointing at one of
+ * `addresses`, minus those voting directly. A superset of who gets credited: a
+ * row here can still lose to a space-specific one pointing elsewhere, which only
+ * `getSnapshotEffectiveDelegates` sees.
  */
-export async function getSnapshotDelegations(
+export async function getSnapshotDelegationCandidates(
   space: string,
   network: string,
   addresses: string[],
   snapshot: number | 'latest'
-): Promise<Record<string, string[]>> {
+): Promise<string[]> {
   const subgraphUrl = SNAPSHOT_SUBGRAPH_URL[network];
-  if (!subgraphUrl) {
-    return {};
+  if (!subgraphUrl || addresses.length === 0) {
+    return [];
   }
 
-  const addressesLc = addresses.map(address => address.toLowerCase());
+  const addressesLc = new Set(addresses.map(address => address.toLowerCase()));
   const spaceIn = buildSpaceIn(space);
 
   const rows = (
     await Promise.all(
-      chunk(addressesLc, CHUNK_SIZE).map(part =>
+      chunk([...addressesLc], CHUNK_SIZE).map(part =>
         queryDelegations(
           subgraphUrl,
           { space_in: spaceIn, delegate_in: part },
@@ -114,54 +117,38 @@ export async function getSnapshotDelegations(
     )
   ).flat();
 
-  // Override + space precedence, identical to `utils/delegation.getDelegations`:
-  // drop delegators that are themselves voting, and let a space-specific
-  // delegation override a global ('') one.
-  const delegations = rows.filter(
-    delegation =>
-      addressesLc.includes(delegation.delegate) &&
-      !addressesLc.includes(delegation.delegator)
-  );
-  const delegationsReverse: Record<string, string> = {};
-  delegations.forEach(
-    delegation =>
-      (delegationsReverse[delegation.delegator] = delegation.delegate)
-  );
-  delegations
-    .filter(delegation => delegation.space !== '')
-    .forEach(
-      delegation =>
-        (delegationsReverse[delegation.delegator] = delegation.delegate)
-    );
-
-  return Object.fromEntries(
-    addresses.map(address => [
-      address,
-      Object.entries(delegationsReverse)
-        .filter(([, delegate]) => address.toLowerCase() === delegate)
-        .map(([delegator]) => getAddress(delegator))
-    ])
-  );
+  return [
+    ...new Set(
+      rows
+        .map(delegation => delegation.delegator)
+        .filter(delegator => !addressesLc.has(delegator))
+    )
+  ];
 }
 
 /**
- * The subset of `delegators` (lowercased) that have **any** Snapshot
- * delegation in the space — used to enforce "Snapshot wins": a Voting delegator
- * is only credited onchain if it has no Snapshot delegation. Address-scoped via
- * `delegator_in`, so it reads only these delegators' rows, not the whole space.
+ * Effective Snapshot delegate per delegator, both lowercased; no entry means no
+ * delegation in the space. Reads every row of each delegator via `delegator_in`,
+ * which is what makes the precedence below correct: a `delegate_in` scoped read
+ * cannot see a competing space-specific row and would credit the wrong delegate.
+ *
+ * Also serves the "Snapshot wins" rule: a Voting delegator counts onchain only
+ * when it has no entry here.
  */
-export async function getSnapshotDelegatorSet(
+export async function getSnapshotEffectiveDelegates(
   space: string,
   network: string,
   delegators: string[],
   snapshot: number | 'latest'
-): Promise<Set<string>> {
+): Promise<Map<string, string>> {
   const subgraphUrl = SNAPSHOT_SUBGRAPH_URL[network];
   if (!subgraphUrl || delegators.length === 0) {
-    return new Set();
+    return new Map();
   }
 
-  const delegatorsLc = delegators.map(delegator => delegator.toLowerCase());
+  const delegatorsLc = [
+    ...new Set(delegators.map(delegator => delegator.toLowerCase()))
+  ];
   const spaceIn = buildSpaceIn(space);
 
   const rows = (
@@ -176,5 +163,17 @@ export async function getSnapshotDelegatorSet(
     )
   ).flat();
 
-  return new Set(rows.map(delegation => delegation.delegator));
+  // Space precedence, as in `utils/delegation.getDelegations`: space-specific
+  // rows overwrite global ('') ones regardless of which came first.
+  const delegateByDelegator = new Map<string, string>();
+  rows.forEach(delegation =>
+    delegateByDelegator.set(delegation.delegator, delegation.delegate)
+  );
+  rows
+    .filter(delegation => delegation.space !== '')
+    .forEach(delegation =>
+      delegateByDelegator.set(delegation.delegator, delegation.delegate)
+    );
+
+  return delegateByDelegator;
 }

--- a/src/strategies/strategies/lido-voting-delegation/votingDelegations.ts
+++ b/src/strategies/strategies/lido-voting-delegation/votingDelegations.ts
@@ -1,0 +1,66 @@
+import { BigNumber } from '@ethersproject/bignumber';
+import { Multicaller } from '../../utils';
+
+// Safe value of delegators returned per getDelegatedVoters call
+const PAGE_SIZE = 1000;
+
+const abi = [
+  'function getDelegatedVotersCount(address _delegate) external view returns (uint256)',
+  'function getDelegatedVoters(address _delegate, uint256 _offset, uint256 _limit) external view returns (address[] voters)'
+];
+
+// Full Lido Voting delegator list per delegate
+export async function getVotingDelegators(
+  network: string,
+  provider: any,
+  votingContract: string,
+  addresses: string[],
+  blockTag: number | string
+): Promise<Record<string, string[]>> {
+  const countMulticaller = new Multicaller(network, provider, abi, {
+    blockTag
+  });
+
+  addresses.forEach(address =>
+    countMulticaller.call(address, votingContract, 'getDelegatedVotersCount', [
+      address
+    ])
+  );
+
+  const delegatedVotersCounts: Record<string, BigNumber> =
+    await countMulticaller.execute();
+
+  const pagesCountsMap: Record<string, number> = {};
+  addresses.forEach(address => {
+    const count = delegatedVotersCounts[address].toNumber();
+    pagesCountsMap[address] = Math.ceil(count / PAGE_SIZE);
+  });
+
+  const delegatedVotersMulticaller = new Multicaller(network, provider, abi, {
+    blockTag
+  });
+
+  for (const address of addresses) {
+    for (let page = 0; page < pagesCountsMap[address]; page++) {
+      delegatedVotersMulticaller.call(
+        `${address}:${page}`,
+        votingContract,
+        'getDelegatedVoters',
+        [address, page * PAGE_SIZE, PAGE_SIZE]
+      );
+    }
+  }
+
+  const pageResults: Record<string, string[]> =
+    await delegatedVotersMulticaller.execute();
+
+  return Object.fromEntries(
+    addresses.map(address => {
+      const delegators: string[] = [];
+      for (let page = 0; page < pagesCountsMap[address]; page++) {
+        delegators.push(...(pageResults[`${address}:${page}`] || []));
+      }
+      return [address, delegators];
+    })
+  );
+}


### PR DESCRIPTION
### Description

New Snapshot strategy that returns **delegated-in LDO voting power** for Lido DAO delegates. For each queried delegate it sums the LDO balances of accounts that delegated to it through **either** of two sources:

- **Snapshot Delegate Registry** (off-chain, via the delegation subgraph)
- **Lido DAO `Voting` contract** (on-chain Aragon delegation)

It returns delegated power only. Delegate's own balance is intentionally excluded, so the space should pair this with `erc20-balance-of` if own balance should count.

### Precedence rules

- **Snapshot wins:** if a holder delegated in both systems, their power follows the Snapshot delegate. A Voting delegation is credited only if the delegator has _no_ Snapshot delegation.
- **Direct voting overrides delegation:** if a delegator is itself in the queried address set (voting directly), its power is excluded from its delegate so it can reclaim it. `overriding: true` is set in the manifest.

### Implementation notes

Snapshot delegation resolution follows **`utils/delegation.getDelegationsData`** semantics rather than `getDelegations`: candidate delegators are found with an address-scoped `delegate_in` query (avoiding the slow whole-space pagination), then each candidate's _complete_ delegation set is re-read via `delegator_in` before applying the space-over-global override. `getDelegations` filters by delegate before the override, so it cannot see a space-specific delegation pointing outside the queried set and would credit the wrong delegate. Scores here can therefore intentionally differ from the `delegation` strategy (documented in the strategy README).

### Parameters

| Param             | Required | Description                                            |
| ----------------- | -------- | ------------------------------------------------------ |
| `address`         | ✅       | LDO token contract                                     |
| `decimals`        | ✅       | Token decimals                                         |
| `votingContract`  | ✅       | Lido DAO `Voting` proxy                                |
| `symbol`          | —        | Display symbol                                         |
| `delegationSpace` | —        | Snapshot delegation space (defaults to proposal space) |
